### PR TITLE
Add MINIMAL pragmas where appropriate

### DIFF
--- a/src/Data/Bifoldable.hs
+++ b/src/Data/Bifoldable.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Bifoldable
@@ -85,6 +86,10 @@ class Bifoldable p where
   bifoldl :: (c -> a -> c) -> (c -> b -> c) -> c -> p a b -> c
   bifoldl f g z t = appEndo (getDual (bifoldMap (Dual . Endo . flip f) (Dual . Endo . flip g) t)) z
   {-# INLINE bifoldl #-}
+
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 708
+  {-# MINIMAL bifoldr | bifoldMap #-}
+#endif
 
 instance Bifoldable (,) where
   bifoldMap f g ~(a, b) = f a `mappend` g b

--- a/src/Data/Bifunctor.hs
+++ b/src/Data/Bifunctor.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Bifunctor
@@ -69,6 +70,10 @@ class Bifunctor p where
   second :: (b -> c) -> p a b -> p a c
   second = bimap id
   {-# INLINE second #-}
+
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 708
+  {-# MINIMAL bimap | first, second #-}
+#endif
 
 instance Bifunctor (,) where
   bimap f g ~(a, b) = (f a, g b)

--- a/src/Data/Bitraversable.hs
+++ b/src/Data/Bitraversable.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Bitraversable
@@ -145,6 +146,10 @@ class (Bifunctor t, Bifoldable t) => Bitraversable t where
   bisequence :: Monad m => t (m a) (m b) -> m (t a b)
   bisequence = bimapM id id
   {-# INLINE bisequence #-}
+
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 708
+  {-# MINIMAL bitraverse | bisequenceA #-}
+#endif
 
 instance Bitraversable (,) where
   bitraverse f g ~(a, b) = (,) <$> f a <*> g b

--- a/src/Data/Semigroup/Bitraversable.hs
+++ b/src/Data/Semigroup/Bitraversable.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Semigroup.Bitraversable
@@ -30,6 +31,10 @@ class (Bifoldable1 t, Bitraversable t) => Bitraversable1 t where
   bisequence1 :: Apply f => t (f a) (f b) -> f (t a b)
   bisequence1 = bitraverse1 id id
   {-# INLINE bisequence1 #-}
+
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 708
+  {-# MINIMAL bitraverse1 | bisequence1 #-}
+#endif
 
 bifoldMap1Default :: (Bitraversable1 t, Semigroup m) => (a -> m) -> (b -> m) -> t a b -> m
 bifoldMap1Default f g = getConst . bitraverse1 (Const . f) (Const . g)


### PR DESCRIPTION
Adds the new `MINIMAL` pragma to:
- Data.Bifoldable
- Data.Bifunctor
- Data.Bitraversable
- Data.Semigroup.Bitraversable

The minimal definition has been taken from the documentation.

These pragmas are only enabled for GHC >= 7.8.1
