### PR TITLE
Backport Typeable Bifunctor instance from GHC 7.10 to GHC 7.8

### DIFF
--- a/old-src/Data/Bifunctor.hs
+++ b/old-src/Data/Bifunctor.hs
@@ -1,5 +1,11 @@
 {-# LANGUAGE CPP #-}
 
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 708 && __GLASGOW_HASKELL__ < 710
+#define LANGUAGE_DeriveDataTypeable
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE StandaloneDeriving #-}
+#endif
+
 #ifndef MIN_VERSION_semigroups
 #define MIN_VERSION_semigroups(x,y,z) 0
 #endif
@@ -25,6 +31,10 @@ import Data.Semigroup
 
 #ifdef MIN_VERSION_tagged
 import Data.Tagged
+#endif
+
+#if defined(LANGUAGE_DeriveDataTypeable)
+import Data.Typeable
 #endif
 
 -- | Minimal definition either 'bimap' or 'first' and 'second'
@@ -83,6 +93,10 @@ class Bifunctor p where
 
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 708
   {-# MINIMAL bimap | first, second #-}
+#endif
+
+#if defined(LANGUAGE_DeriveDataTypeable)
+deriving instance Typeable Bifunctor
 #endif
 
 instance Bifunctor (,) where


### PR DESCRIPTION
In the spirit of achieving parity with `base`, this adds a `Typeable Bifunctor` instance to `Data.Bifunctor`, since GHC 7.10 automatically derives `Typeable` instances for all typeclasses. This can only be backported to GHC 7.8, since that was when poly-kinded `Typeable` was first introduced.

I only added an instance for `Bifunctor`. If you'd want backported `Typeable` instances for the other typeclasses in this package, let me know.