### PR TITLE
Typeable instances on GHC 7.8+

### DIFF
--- a/old-src/Data/Bifunctor.hs
+++ b/old-src/Data/Bifunctor.hs
@@ -1,4 +1,8 @@
 {-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE StandaloneDeriving #-}
+#endif
 
 #ifndef MIN_VERSION_semigroups
 #define MIN_VERSION_semigroups(x,y,z) 0
@@ -25,6 +29,10 @@ import Data.Semigroup
 
 #ifdef MIN_VERSION_tagged
 import Data.Tagged
+#endif
+
+#if __GLASGOW_HASKELL__ >= 708
+import Data.Typeable
 #endif
 
 -- | Minimal definition either 'bimap' or 'first' and 'second'
@@ -81,8 +89,10 @@ class Bifunctor p where
   second = bimap id
   {-# INLINE second #-}
 
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 708
+#if __GLASGOW_HASKELL__ >= 708
   {-# MINIMAL bimap | first, second #-}
+
+deriving instance Typeable Bifunctor
 #endif
 
 instance Bifunctor (,) where

--- a/src/Data/Bifoldable.hs
+++ b/src/Data/Bifoldable.hs
@@ -1,4 +1,8 @@
 {-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE StandaloneDeriving #-}
+#endif
 
 #ifndef MIN_VERSION_semigroups
 #define MIN_VERSION_semigroups(x,y,z) 0
@@ -42,6 +46,10 @@ import Data.Monoid
 
 #ifdef MIN_VERSION_tagged
 import Data.Tagged
+#endif
+
+#if __GLASGOW_HASKELL__ >= 708
+import Data.Typeable
 #endif
 
 -- | Minimal definition either 'bifoldr' or 'bifoldMap'
@@ -98,8 +106,10 @@ class Bifoldable p where
   bifoldl f g z t = appEndo (getDual (bifoldMap (Dual . Endo . flip f) (Dual . Endo . flip g) t)) z
   {-# INLINE bifoldl #-}
 
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 708
+#if __GLASGOW_HASKELL__ >= 708
   {-# MINIMAL bifoldr | bifoldMap #-}
+
+deriving instance Typeable Bifoldable
 #endif
 
 #if MIN_VERSION_semigroups(0,16,2)

--- a/src/Data/Bifunctor/Biff.hs
+++ b/src/Data/Bifunctor/Biff.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE DeriveDataTypeable #-}
+#endif
+
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2008-2015 Edward Kmett
@@ -19,10 +24,17 @@ import Data.Bitraversable
 import Data.Foldable
 import Data.Monoid
 import Data.Traversable
+#if __GLASGOW_HASKELL__ >= 708
+import Data.Typeable
+#endif
 
 -- | Compose two 'Functor's on the inside of a 'Bifunctor'.
 newtype Biff p f g a b = Biff { runBiff :: p (f a) (g b) }
-  deriving (Eq,Ord,Show,Read)
+  deriving ( Eq, Ord, Show, Read
+#if __GLASGOW_HASKELL__ >= 708
+           , Typeable
+#endif
+           )
 
 instance (Bifunctor p, Functor f, Functor g) => Bifunctor (Biff p f g) where
   first f = Biff . first (fmap f) . runBiff

--- a/src/Data/Bifunctor/Clown.hs
+++ b/src/Data/Bifunctor/Clown.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE DeriveDataTypeable #-}
+#endif
+
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2008-2015 Edward Kmett
@@ -21,13 +26,20 @@ import Data.Bitraversable
 import Data.Foldable
 import Data.Monoid
 import Data.Traversable
+#if __GLASGOW_HASKELL__ >= 708
+import Data.Typeable
+#endif
 
 -- | Make a 'Functor' over the first argument of a 'Bifunctor'.
 --
 -- Mnemonic: C__l__owns to the __l__eft (parameter of the Bifunctor),
 --           joke__r__s to the __r__ight.
 newtype Clown f a b = Clown { runClown :: f a }
-  deriving (Eq,Ord,Show,Read)
+  deriving ( Eq, Ord, Show, Read
+#if __GLASGOW_HASKELL__ >= 708
+           , Typeable
+#endif
+           )
 
 instance Functor f => Bifunctor (Clown f) where
   first f = Clown . fmap f . runClown

--- a/src/Data/Bifunctor/Flip.hs
+++ b/src/Data/Bifunctor/Flip.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE DeriveDataTypeable #-}
+#endif
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Bifunctor.Flip
@@ -20,10 +25,17 @@ import Data.Bitraversable
 import Data.Foldable
 import Data.Monoid
 import Data.Traversable
+#if __GLASGOW_HASKELL__ >= 708
+import Data.Typeable
+#endif
 
 -- | Make a 'Bifunctor' flipping the arguments of a 'Bifunctor'.
 newtype Flip p a b = Flip { runFlip :: p b a }
-  deriving (Eq,Ord,Show,Read)
+  deriving ( Eq, Ord, Show, Read
+#if __GLASGOW_HASKELL__ >= 708
+           , Typeable
+#endif
+           )
 
 instance Bifunctor p => Bifunctor (Flip p) where
   first f = Flip . second f . runFlip

--- a/src/Data/Bifunctor/Join.hs
+++ b/src/Data/Bifunctor/Join.hs
@@ -1,4 +1,8 @@
-{-# LANGUAGE StandaloneDeriving, FlexibleContexts, UndecidableInstances #-}
+{-# LANGUAGE CPP, StandaloneDeriving, FlexibleContexts, UndecidableInstances #-}
+#if __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE DeriveDataTypeable #-}
+#endif
+
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2008-2015 Edward Kmett
@@ -19,9 +23,15 @@ import Data.Bifoldable
 import Data.Bitraversable
 import Data.Foldable
 import Data.Traversable
+#if __GLASGOW_HASKELL__ >= 708
+import Data.Typeable
+#endif
 
 -- | Make a 'Functor' over both arguments of a 'Bifunctor'.
 newtype Join p a = Join { runJoin :: p a a }
+#if __GLASGOW_HASKELL__ >= 708
+  deriving Typeable
+#endif
 
 deriving instance Eq   (p a a) => Eq   (Join p a)
 deriving instance Ord  (p a a) => Ord  (Join p a)

--- a/src/Data/Bifunctor/Joker.hs
+++ b/src/Data/Bifunctor/Joker.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE DeriveDataTypeable #-}
+#endif
+
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2008-2015 Edward Kmett
@@ -20,13 +25,20 @@ import Data.Bifoldable
 import Data.Bitraversable
 import Data.Foldable
 import Data.Traversable
+#if __GLASGOW_HASKELL__ >= 708
+import Data.Typeable
+#endif
 
 -- | Make a 'Functor' over the second argument of a 'Bifunctor'.
 --
 -- Mnemonic: C__l__owns to the __l__eft (parameter of the Bifunctor),
 --           joke__r__s to the __r__ight.
 newtype Joker g a b = Joker { runJoker :: g b }
-  deriving (Eq,Ord,Show,Read)
+  deriving ( Eq, Ord, Show, Read
+#if __GLASGOW_HASKELL__ >= 708
+           , Typeable
+#endif
+           )
 
 instance Functor g => Bifunctor (Joker g) where
   first _ = Joker . runJoker

--- a/src/Data/Bifunctor/Product.hs
+++ b/src/Data/Bifunctor/Product.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE DeriveDataTypeable #-}
+#endif
+
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2008-2015 Jesse Selover, Edward Kmett
@@ -18,9 +23,17 @@ import Data.Biapplicative
 import Data.Bifoldable
 import Data.Bitraversable
 import Data.Monoid hiding (Product)
+#if __GLASGOW_HASKELL__ >= 708
+import Data.Typeable
+#endif
 
 -- | Form the product of two bifunctors
-data Product f g a b = Pair (f a b) (g a b) deriving (Eq,Ord,Show,Read)
+data Product f g a b = Pair (f a b) (g a b)
+  deriving ( Eq, Ord, Show, Read
+#if __GLASGOW_HASKELL__ >= 708
+           , Typeable
+#endif
+           )
 
 instance (Bifunctor f, Bifunctor g) => Bifunctor (Product f g) where
   first f (Pair x y) = Pair (first f x) (first f y)

--- a/src/Data/Bifunctor/Tannen.hs
+++ b/src/Data/Bifunctor/Tannen.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE DeriveDataTypeable #-}
+#endif
+
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2008-2015 Edward Kmett
@@ -19,10 +24,17 @@ import Data.Bitraversable
 import Data.Foldable
 import Data.Monoid
 import Data.Traversable
+#if __GLASGOW_HASKELL__ >= 708
+import Data.Typeable
+#endif
 
 -- | Compose a 'Functor' on the outside of a 'Bifunctor'.
 newtype Tannen f p a b = Tannen { runTannen :: f (p a b) }
-  deriving (Eq,Ord,Show,Read)
+  deriving ( Eq, Ord, Show, Read
+#if __GLASGOW_HASKELL__ >= 708
+           , Typeable
+#endif
+           )
 
 instance (Functor f, Bifunctor p) => Bifunctor (Tannen f p) where
   first f = Tannen . fmap (first f) . runTannen

--- a/src/Data/Bifunctor/Wrapped.hs
+++ b/src/Data/Bifunctor/Wrapped.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE DeriveDataTypeable #-}
+#endif
+
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2008-2015 Edward Kmett
@@ -19,10 +24,17 @@ import Data.Bitraversable
 import Data.Foldable
 import Data.Monoid
 import Data.Traversable
+#if __GLASGOW_HASKELL__ >= 708
+import Data.Typeable
+#endif
 
 -- | Make a 'Functor' over the second argument of a 'Bifunctor'.
 newtype WrappedBifunctor p a b = WrapBifunctor { unwrapBifunctor :: p a b }
-  deriving (Eq,Ord,Show,Read)
+  deriving ( Eq, Ord, Show, Read
+#if __GLASGOW_HASKELL__ >= 708
+           , Typeable
+#endif
+           )
 
 instance Bifunctor p => Bifunctor (WrappedBifunctor p) where
   first f = WrapBifunctor . first f . unwrapBifunctor

--- a/src/Data/Bitraversable.hs
+++ b/src/Data/Bitraversable.hs
@@ -1,4 +1,8 @@
 {-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE StandaloneDeriving #-}
+#endif
 
 #ifndef MIN_VERSION_semigroups
 #define MIN_VERSION_semigroups(x,y,z) 0
@@ -35,6 +39,10 @@ import Data.Monoid
 
 #ifdef MIN_VERSION_tagged
 import Data.Tagged
+#endif
+
+#if __GLASGOW_HASKELL__ >= 708
+import Data.Typeable
 #endif
 
 -- | Minimal complete definition either 'bitraverse' or 'bisequenceA'.
@@ -160,6 +168,8 @@ class (Bifunctor t, Bifoldable t) => Bitraversable t where
 
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 708
   {-# MINIMAL bitraverse | bisequenceA #-}
+
+deriving instance Typeable Bitraversable
 #endif
 
 #if MIN_VERSION_semigroups(0,16,2)


### PR DESCRIPTION
Take two at this (after #21, which had some issues with Travis).

This adds `Typeable` instances for all data types and typeclasses on GHC 7.8 and up (since they all require polykinded `Typeable` to work).