### PR TITLE
Fix a haddock parse error

### DIFF
--- a/src/Data/Bifunctor/TH.hs
+++ b/src/Data/Bifunctor/TH.hs
@@ -671,8 +671,8 @@ buildTypeInstanceFromTys biClass tyConName dataCxt varTysOrig isDataFamily = do
         droppedTyVarNames :: [Name]
         droppedTyVarNames = concatMap tyVarNamesOfType droppedTysExpSubst
 
-    -- If any of the dropped types were polykinded, ensure that there are of kind
-    -- * after substituting * for the dropped kind variables. If not, throw an error.
+    -- If any of the dropped types were polykinded, ensure that there are of kind *
+    -- after substituting * for the dropped kind variables. If not, throw an error.
     unless (all hasKindStar droppedTysExpSubst) $
       derivingKindError biClass tyConName
 


### PR DESCRIPTION
Before the change, I am getting the following error when running haddock:

```
src/Data/Bifunctor/TH.hs:675:5:
    parse error on input `-- * after substituting * for the dropped kind variables. If not, throw an error.'
```

Simply moving the first `*` to the end of previous line fixes this for me.