### PR TITLE
Add more functions to Data.Bifoldable

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,6 @@
 next
 ----
+* Added `bifoldr1`, `bifoldl1`, `bimsum`, `biasum`, `binull`, `bilength`, `bielem`, `bimaximum`, `biminimum`, `bisum`, `biproduct`, `biand`, `bior`, `bimaximumBy`, `biminimumBy`, `binotElem`, and `bifind` to `Data.Bifoldable`
 * Added `Bifunctor`, `Bifoldable`, and `Bitraversable` instances for `GHC.Generics.K1`
 * TH code no longer generates superfluous `mempty` or `pure` subexpressions in derived `Bifoldable` or `Bitraversable` instances, respectively
 


### PR DESCRIPTION
This adds more functions to `Data.Bifoldable` to make it have the same number of features as `Data.Foldable`. The functions are:

* `bifoldr1`
* `bifoldl1`
* `bimsum`
* `biasum`
* `binull`
* `bilength`
* `bielem`
* `bimaximum`
* `biminimum`
* `bisum`
* `biproduct`
* `biand`
* `bior`
* `bimaximumBy`
* `biminimumBy`
* `binotElem`
* `bifind`