### PR TITLE
Add dependency to template-haskell in test-suite

### DIFF
--- a/bifunctors.cabal
+++ b/bifunctors.cabal
@@ -99,6 +99,7 @@ test-suite bifunctors-spec
     bifunctors,
     hspec               >= 1.8,
     QuickCheck          >= 2   && < 3,
+    template-haskell,
     transformers,
     transformers-compat
 


### PR DESCRIPTION
Cabal >=1.25 generates per component cabal_macros.h, and we use
MIN_VERSION_template_haskell in the specs.