### PR TITLE
Don't incur a semigroups dependency on recent GHCs.

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+Next
+----
+* Don't incur a `semigroup` dependency on recent GHCs.
+
 5.5.3 [2018.07.04]
 ------------------
 * Make `biliftA2` a class method of `Biapplicative`.

--- a/bifunctors.cabal
+++ b/bifunctors.cabal
@@ -62,7 +62,7 @@ library
   if flag(tagged)
     build-depends: tagged >= 0.7.3 && < 1
 
-  if flag(semigroups)
+  if flag(semigroups) && !impl(ghc >= 8.0)
     build-depends: semigroups >= 0.8.3.1 && < 1
 
   if impl(ghc<7.9)


### PR DESCRIPTION
No need to bump the version this time since everything seems to be
properly CPPed already.