### PR TITLE
Add {Eq,Ord,Read,Show}{1,2} instances where possible

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,10 @@
+next [????.??.??]
+* Add `Eq{1,2}`, `Ord{1,2}`, `Read{1,2}`, and `Show{1,2}` instances for data
+  types in the `Data.Bifunctor.*` module namespace where possible. The
+  operative phrase is "where possible" since many of these instances require
+  the use of `Eq2`/`Ord2`/`Read2`/`Show2`, which are not avaiable when
+  built against `transformers-0.4.*`.
+
 5.5.4 [2019.04.26]
 ------------------
 * Support `th-abstraction-0.3` or later.

--- a/bifunctors.cabal
+++ b/bifunctors.cabal
@@ -24,7 +24,11 @@ tested-with:   GHC == 7.0.4
              , GHC == 8.4.4
              , GHC == 8.6.5
              , GHC == 8.8.1
-extra-source-files: .travis.yml CHANGELOG.markdown README.markdown
+extra-source-files:
+  .travis.yml
+  CHANGELOG.markdown
+  README.markdown
+  include/bifunctors-common.h
 
 source-repository head
   type: git
@@ -48,6 +52,8 @@ flag tagged
 
 library
   hs-source-dirs: src
+  include-dirs: include
+  includes: bifunctors-common.h
   build-depends:
     base                >= 4     && < 5,
     base-orphans        >= 0.5.2 && < 1,

--- a/include/bifunctors-common.h
+++ b/include/bifunctors-common.h
@@ -1,0 +1,19 @@
+#ifndef MIN_VERSION_base
+#define MIN_VERSION_base(x,y,z) 1
+#endif
+
+#ifndef MIN_VERSION_transformers_compat
+#define MIN_VERSION_transformers_compat(x,y,z) 0
+#endif
+
+#if MIN_VERSION_base(4,9,0)
+#define LIFTED_FUNCTOR_CLASSES 1
+#else
+#if MIN_VERSION_transformers(0,5,0)
+#define LIFTED_FUNCTOR_CLASSES 1
+#else
+#if MIN_VERSION_transformers_compat(0,5,0) && !MIN_VERSION_transformers(0,4,0)
+#define LIFTED_FUNCTOR_CLASSES 1
+#endif
+#endif
+#endif

--- a/src/Data/Bifunctor/Fix.hs
+++ b/src/Data/Bifunctor/Fix.hs
@@ -17,6 +17,7 @@
 #if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE PolyKinds #-}
 #endif
+#include "bifunctors-common.h"
 
 -----------------------------------------------------------------------------
 -- |
@@ -54,6 +55,10 @@ import Data.Typeable
 import GHC.Generics
 #endif
 
+#if LIFTED_FUNCTOR_CLASSES
+import Data.Functor.Classes
+#endif
+
 -- | Greatest fixpoint of a 'Bifunctor' (a 'Functor' over the first argument with zipping).
 newtype Fix p a = In { out :: p (Fix p a) a }
   deriving
@@ -71,6 +76,30 @@ deriving instance Ord  (p (Fix p a) a) => Ord  (Fix p a)
 deriving instance Show (p (Fix p a) a) => Show (Fix p a)
 deriving instance Read (p (Fix p a) a) => Read (Fix p a)
 
+#if LIFTED_FUNCTOR_CLASSES
+instance Eq2 p => Eq1 (Fix p) where
+  liftEq f (In x) (In y) = liftEq2 (liftEq f) f x y
+
+instance Ord2 p => Ord1 (Fix p) where
+  liftCompare f (In x) (In y) = liftCompare2 (liftCompare f) f x y
+
+instance Read2 p => Read1 (Fix p) where
+  liftReadsPrec rp1 rl1 p = readParen (p > 10) $ \s0 -> do
+    ("In",  s1) <- lex s0
+    ("{",   s2) <- lex s1
+    ("out", s3) <- lex s2
+    (x,     s4) <- liftReadsPrec2 (liftReadsPrec rp1 rl1) (liftReadList rp1 rl1)
+                                  rp1 rl1 0 s3
+    ("}",   s5) <- lex s4
+    return (In x, s5)
+
+instance Show2 p => Show1 (Fix p) where
+  liftShowsPrec sp1 sl1 p (In x) = showParen (p > 10) $
+      showString "In {out = "
+    . liftShowsPrec2 (liftShowsPrec sp1 sl1) (liftShowList sp1 sl1)
+                     sp1 sl1 0 x
+    . showChar '}'
+#endif
 
 instance Bifunctor p => Functor (Fix p) where
   fmap f (In p) = In (bimap (fmap f) f p)

--- a/src/Data/Bifunctor/Flip.hs
+++ b/src/Data/Bifunctor/Flip.hs
@@ -14,6 +14,7 @@
 #if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE PolyKinds #-}
 #endif
+#include "bifunctors-common.h"
 
 -----------------------------------------------------------------------------
 -- |
@@ -53,6 +54,10 @@ import Data.Typeable
 import GHC.Generics
 #endif
 
+#if LIFTED_FUNCTOR_CLASSES
+import Data.Functor.Classes
+#endif
+
 -- | Make a 'Bifunctor' flipping the arguments of a 'Bifunctor'.
 newtype Flip p a b = Flip { runFlip :: p b a }
   deriving ( Eq, Ord, Show, Read
@@ -63,6 +68,37 @@ newtype Flip p a b = Flip { runFlip :: p b a }
            , Typeable
 #endif
            )
+
+#if LIFTED_FUNCTOR_CLASSES
+instance (Eq2 p, Eq a) => Eq1 (Flip p a) where
+  liftEq = liftEq2 (==)
+instance Eq2 p => Eq2 (Flip p) where
+  liftEq2 f g (Flip x) (Flip y) = liftEq2 g f x y
+
+instance (Ord2 p, Ord a) => Ord1 (Flip p a) where
+  liftCompare = liftCompare2 compare
+instance Ord2 p => Ord2 (Flip p) where
+  liftCompare2 f g (Flip x) (Flip y) = liftCompare2 g f x y
+
+instance (Read2 p, Read a) => Read1 (Flip p a) where
+  liftReadsPrec = liftReadsPrec2 readsPrec readList
+instance Read2 p => Read2 (Flip p) where
+  liftReadsPrec2 rp1 rl1 rp2 rl2 p = readParen (p > 10) $ \s0 -> do
+    ("Flip",    s1) <- lex s0
+    ("{",       s2) <- lex s1
+    ("runFlip", s3) <- lex s2
+    (x,         s4) <- liftReadsPrec2 rp2 rl2 rp1 rl1 0 s3
+    ("}",       s5) <- lex s4
+    return (Flip x, s5)
+
+instance (Show2 p, Show a) => Show1 (Flip p a) where
+  liftShowsPrec = liftShowsPrec2 showsPrec showList
+instance Show2 p => Show2 (Flip p) where
+  liftShowsPrec2 sp1 sl1 sp2 sl2 p (Flip x) = showParen (p > 10) $
+      showString "Flip {runFlip = "
+    . liftShowsPrec2 sp2 sl2 sp1 sl1 0 x
+    . showChar '}'
+#endif
 
 instance Bifunctor p => Bifunctor (Flip p) where
   first f = Flip . second f . runFlip

--- a/src/Data/Bifunctor/Join.hs
+++ b/src/Data/Bifunctor/Join.hs
@@ -17,6 +17,7 @@
 #if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE PolyKinds #-}
 #endif
+#include "bifunctors-common.h"
 
 -----------------------------------------------------------------------------
 -- |
@@ -53,6 +54,10 @@ import Data.Typeable
 import GHC.Generics
 #endif
 
+#if LIFTED_FUNCTOR_CLASSES
+import Data.Functor.Classes
+#endif
+
 -- | Make a 'Functor' over both arguments of a 'Bifunctor'.
 newtype Join p a = Join { runJoin :: p a a }
   deriving
@@ -69,6 +74,29 @@ deriving instance Eq   (p a a) => Eq   (Join p a)
 deriving instance Ord  (p a a) => Ord  (Join p a)
 deriving instance Show (p a a) => Show (Join p a)
 deriving instance Read (p a a) => Read (Join p a)
+
+#if LIFTED_FUNCTOR_CLASSES
+instance Eq2 p => Eq1 (Join p) where
+  liftEq f (Join x) (Join y) = liftEq2 f f x y
+
+instance Ord2 p => Ord1 (Join p) where
+  liftCompare f (Join x) (Join y) = liftCompare2 f f x y
+
+instance Read2 p => Read1 (Join p) where
+  liftReadsPrec rp1 rl1 p = readParen (p > 10) $ \s0 -> do
+    ("Join",    s1) <- lex s0
+    ("{",       s2) <- lex s1
+    ("runJoin", s3) <- lex s2
+    (x,         s4) <- liftReadsPrec2 rp1 rl1 rp1 rl1 0 s3
+    ("}",       s5) <- lex s4
+    return (Join x, s5)
+
+instance Show2 p => Show1 (Join p) where
+  liftShowsPrec sp1 sl1 p (Join x) = showParen (p > 10) $
+      showString "Join {runJoin = "
+    . liftShowsPrec2 sp1 sl1 sp1 sl1 0 x
+    . showChar '}'
+#endif
 
 instance Bifunctor p => Functor (Join p) where
   fmap f (Join a) = Join (bimap f f a)

--- a/src/Data/Bifunctor/Joker.hs
+++ b/src/Data/Bifunctor/Joker.hs
@@ -16,6 +16,7 @@
 #elif __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
 #endif
+#include "bifunctors-common.h"
 
 -----------------------------------------------------------------------------
 -- |
@@ -40,6 +41,7 @@ import Control.Applicative
 import Data.Biapplicative
 import Data.Bifoldable
 import Data.Bitraversable
+import Data.Functor.Classes
 
 #if __GLASGOW_HASKELL__ < 710
 import Data.Foldable
@@ -91,6 +93,67 @@ instance Generic1 (Joker g a) where
     from1 = M1 . M1 . M1 . Rec1 . runJoker
     to1 = Joker . unRec1 . unM1 . unM1 . unM1
 #endif
+
+#if LIFTED_FUNCTOR_CLASSES
+instance Eq1 g => Eq1 (Joker g a) where
+  liftEq g = eqJoker (liftEq g)
+instance Eq1 g => Eq2 (Joker g) where
+  liftEq2 _ g = eqJoker (liftEq g)
+
+instance Ord1 g => Ord1 (Joker g a) where
+  liftCompare g = compareJoker (liftCompare g)
+instance Ord1 g => Ord2 (Joker g) where
+  liftCompare2 _ g = compareJoker (liftCompare g)
+
+instance Read1 g => Read1 (Joker g a) where
+  liftReadsPrec rp rl = readsPrecJoker (liftReadsPrec rp rl)
+instance Read1 g => Read2 (Joker g) where
+  liftReadsPrec2 _ _ rp2 rl2 = readsPrecJoker (liftReadsPrec rp2 rl2)
+
+instance Show1 g => Show1 (Joker g a) where
+  liftShowsPrec sp sl = showsPrecJoker (liftShowsPrec sp sl)
+instance Show1 g => Show2 (Joker g) where
+  liftShowsPrec2 _ _ sp2 sl2 = showsPrecJoker (liftShowsPrec sp2 sl2)
+#else
+instance Eq1 g => Eq1 (Joker g a) where
+  eq1 = eqJoker eq1
+
+instance Ord1 g => Ord1 (Joker g a) where
+  compare1 = compareJoker compare1
+
+instance Read1 g => Read1 (Joker g a) where
+  readsPrec1 = readsPrecJoker readsPrec1
+
+instance Show1 g => Show1 (Joker g a) where
+  showsPrec1 = showsPrecJoker showsPrec1
+#endif
+
+eqJoker :: (g b1 -> g b2 -> Bool)
+        -> Joker g a1 b1 -> Joker g a2 b2 -> Bool
+eqJoker eqB (Joker x) (Joker y) = eqB x y
+
+compareJoker :: (g b1 -> g b2 -> Ordering)
+             -> Joker g a1 b1 -> Joker g a2 b2 -> Ordering
+compareJoker compareB (Joker x) (Joker y) = compareB x y
+
+readsPrecJoker :: (Int -> ReadS (g b))
+               -> Int -> ReadS (Joker g a b)
+readsPrecJoker rpB p =
+  readParen (p > 10) $ \s0 -> do
+    ("Joker",    s1) <- lex s0
+    ("{",        s2) <- lex s1
+    ("runJoker", s3) <- lex s2
+    (x,          s4) <- rpB 0 s3
+    ("}",        s5) <- lex s4
+    return (Joker x, s5)
+
+showsPrecJoker :: (Int -> g b -> ShowS)
+               -> Int -> Joker g a b -> ShowS
+showsPrecJoker spB p (Joker x) =
+  showParen (p > 10) $
+      showString "Joker {runJoker = "
+    . spB 0 x
+    . showChar '}'
 
 instance Functor g => Bifunctor (Joker g) where
   first _ = Joker . runJoker

--- a/src/Data/Bifunctor/Sum.hs
+++ b/src/Data/Bifunctor/Sum.hs
@@ -16,6 +16,7 @@
 #elif __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
 #endif
+#include "bifunctors-common.h"
 
 module Data.Bifunctor.Sum where
 
@@ -23,14 +24,19 @@ import Data.Bifunctor
 import Data.Bifunctor.Functor
 import Data.Bifoldable
 import Data.Bitraversable
+
 #if __GLASGOW_HASKELL__ < 710
 import Data.Functor
+import Data.Monoid hiding (Sum)
 #endif
 #if __GLASGOW_HASKELL__ >= 708
 import Data.Typeable
 #endif
 #if __GLASGOW_HASKELL__ >= 702
 import GHC.Generics
+#endif
+#if LIFTED_FUNCTOR_CLASSES
+import Data.Functor.Classes
 #endif
 
 data Sum p q a b = L2 (p a b) | R2 (q a b)
@@ -67,6 +73,39 @@ instance Generic1 (Sum p q a) where
     from1 (R2 q) = M1 (R1 (M1 (M1 (Rec1 q))))
     to1 (M1 (L1 (M1 (M1 p)))) = L2 (unRec1 p)
     to1 (M1 (R1 (M1 (M1 q)))) = R2 (unRec1 q)
+#endif
+
+#if LIFTED_FUNCTOR_CLASSES
+instance (Eq2 f, Eq2 g, Eq a) => Eq1 (Sum f g a) where
+  liftEq = liftEq2 (==)
+instance (Eq2 f, Eq2 g) => Eq2 (Sum f g) where
+  liftEq2 f g (L2 x1) (L2 x2) = liftEq2 f g x1 x2
+  liftEq2 _ _ (L2 _)  (R2 _)  = False
+  liftEq2 _ _ (R2 _)  (L2 _)  = False
+  liftEq2 f g (R2 y1) (R2 y2) = liftEq2 f g y1 y2
+
+instance (Ord2 f, Ord2 g, Ord a) => Ord1 (Sum f g a) where
+  liftCompare = liftCompare2 compare
+instance (Ord2 f, Ord2 g) => Ord2 (Sum f g) where
+  liftCompare2 f g (L2 x1) (L2 x2) = liftCompare2 f g x1 x2
+  liftCompare2 _ _ (L2 _)  (R2 _)  = LT
+  liftCompare2 _ _ (R2 _)  (L2 _)  = GT
+  liftCompare2 f g (R2 y1) (R2 y2) = liftCompare2 f g y1 y2
+
+instance (Read2 f, Read2 g, Read a) => Read1 (Sum f g a) where
+  liftReadsPrec = liftReadsPrec2 readsPrec readList
+instance (Read2 f, Read2 g) => Read2 (Sum f g) where
+  liftReadsPrec2 rp1 rl1 rp2 rl2 = readsData $
+    readsUnaryWith (liftReadsPrec2 rp1 rl1 rp2 rl2) "L2" L2 `mappend`
+    readsUnaryWith (liftReadsPrec2 rp1 rl1 rp2 rl2) "R2" R2
+
+instance (Show2 f, Show2 g, Show a) => Show1 (Sum f g a) where
+  liftShowsPrec = liftShowsPrec2 showsPrec showList
+instance (Show2 f, Show2 g) => Show2 (Sum f g) where
+  liftShowsPrec2 sp1 sl1 sp2 sl2 p (L2 x) =
+    showsUnaryWith (liftShowsPrec2 sp1 sl1 sp2 sl2) "L2" p x
+  liftShowsPrec2 sp1 sl1 sp2 sl2 p (R2 y) =
+    showsUnaryWith (liftShowsPrec2 sp1 sl1 sp2 sl2) "R2" p y
 #endif
 
 instance (Bifunctor p, Bifunctor q) => Bifunctor (Sum p q) where


### PR DESCRIPTION
While we cannot define these instances in conjunction with all versions of `transformers` that `bifunctors` currently supports, they're useful enough (see https://github.com/ekmett/bifunctors/issues/76#issuecomment-504477806) to warrant inclusion, even if guarded behind CPP.

Fixes #58.