### PR TITLE
Require at least semigroups-0.16.2, removes some CPP

### DIFF
--- a/bifunctors.cabal
+++ b/bifunctors.cabal
@@ -74,7 +74,7 @@ library
     build-depends: tagged >= 0.7.3 && < 1
 
   if flag(semigroups) && !impl(ghc >= 8.0)
-    build-depends: semigroups >= 0.8.3.1 && < 1
+    build-depends: semigroups >= 0.16.2 && < 1
 
   if impl(ghc<7.9)
     hs-source-dirs: old-src/ghc709

--- a/old-src/ghc709/Data/Bifunctor.hs
+++ b/old-src/ghc709/Data/Bifunctor.hs
@@ -8,9 +8,6 @@
 {-# LANGUAGE Trustworthy #-}
 #endif
 
-#ifndef MIN_VERSION_semigroups
-#define MIN_VERSION_semigroups(x,y,z) 0
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2008-2015 Edward Kmett
@@ -33,10 +30,7 @@ module Data.Bifunctor
 
 import Control.Applicative
 import Data.Functor.Constant
-
-#if MIN_VERSION_semigroups(0,16,2)
 import Data.Semigroup
-#endif
 
 #ifdef MIN_VERSION_tagged
 import Data.Tagged
@@ -116,10 +110,8 @@ instance Bifunctor (,) where
   bimap f g ~(a, b) = (f a, g b)
   {-# INLINE bimap #-}
 
-#if MIN_VERSION_semigroups(0,16,2)
 instance Bifunctor Arg where
   bimap f g (Arg a b) = Arg (f a) (g b)
-#endif
 
 instance Bifunctor ((,,) x) where
   bimap f g ~(x, a, b) = (x, f a, g b)

--- a/old-src/ghc801/Data/Bifoldable.hs
+++ b/old-src/ghc801/Data/Bifoldable.hs
@@ -7,9 +7,6 @@
 {-# LANGUAGE Trustworthy #-}
 #endif
 
-#ifndef MIN_VERSION_semigroups
-#define MIN_VERSION_semigroups(x,y,z) 0
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2011-2015 Edward Kmett
@@ -68,9 +65,7 @@ import Data.Coerce
 import Unsafe.Coerce
 #endif
 
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_semigroups(0,16,2)
 import Data.Semigroup (Arg(..))
-#endif
 
 #ifdef MIN_VERSION_tagged
 import Data.Tagged
@@ -159,10 +154,8 @@ class Bifoldable p where
 deriving instance Typeable Bifoldable
 #endif
 
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_semigroups(0,16,2)
 instance Bifoldable Arg where
   bifoldMap f g (Arg a b) = f a `mappend` g b
-#endif
 
 instance Bifoldable (,) where
   bifoldMap f g ~(a, b) = f a `mappend` g b

--- a/old-src/ghc801/Data/Bitraversable.hs
+++ b/old-src/ghc801/Data/Bitraversable.hs
@@ -7,9 +7,6 @@
 {-# LANGUAGE Trustworthy #-}
 #endif
 
-#ifndef MIN_VERSION_semigroups
-#define MIN_VERSION_semigroups(x,y,z) 0
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2011-2015 Edward Kmett
@@ -51,9 +48,7 @@ import Unsafe.Coerce (unsafeCoerce)
 import Data.Monoid
 #endif
 
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_semigroups(0,16,2)
 import Data.Semigroup (Arg(..))
-#endif
 
 #ifdef MIN_VERSION_tagged
 import Data.Tagged
@@ -185,10 +180,8 @@ bisequence = bimapM id id
 deriving instance Typeable Bitraversable
 #endif
 
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_semigroups(0,16,2)
 instance Bitraversable Arg where
   bitraverse f g (Arg a b) = Arg <$> f a <*> g b
-#endif
 
 instance Bitraversable (,) where
   bitraverse f g ~(a, b) = (,) <$> f a <*> g b

--- a/src/Data/Biapplicative.hs
+++ b/src/Data/Biapplicative.hs
@@ -7,9 +7,6 @@
 {-# LANGUAGE Trustworthy #-}
 #endif
 
-#ifndef MIN_VERSION_semigroups
-#define MIN_VERSION_semigroups(x,y,z) 0
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2011-2015 Edward Kmett
@@ -42,9 +39,7 @@ import Data.Monoid
 import Data.Traversable (Traversable (traverse))
 #endif
 
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_semigroups(0,16,2)
 import Data.Semigroup (Arg(..))
-#endif
 
 #ifdef MIN_VERSION_tagged
 import Data.Tagged
@@ -278,7 +273,6 @@ instance Biapplicative (,) where
   biliftA2 f g (x, y) (a, b) = (f x a, g y b)
   {-# INLINE biliftA2 #-}
 
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_semigroups(0,16,2)
 instance Biapplicative Arg where
   bipure = Arg
   {-# INLINE bipure #-}
@@ -286,7 +280,6 @@ instance Biapplicative Arg where
   {-# INLINE (<<*>>) #-}
   biliftA2 f g (Arg x y) (Arg a b) = Arg (f x a) (g y b)
   {-# INLINE biliftA2 #-}
-#endif
 
 instance Monoid x => Biapplicative ((,,) x) where
   bipure = (,,) mempty

--- a/src/Data/Bifunctor/Biap.hs
+++ b/src/Data/Bifunctor/Biap.hs
@@ -11,9 +11,6 @@
 #endif
 
 #include "bifunctors-common.h"
-#ifndef MIN_VERSION_semigroups
-#define MIN_VERSION_semigroups(x,y,z) 0
-#endif
 
 -----------------------------------------------------------------------------
 -- |
@@ -47,9 +44,7 @@ import Data.Monoid
 import Data.Traversable
 #endif
 
-#if MIN_VERSION_base(4,9,0) || MIN_VERSION_semigroups(0,16,2)
 import qualified Data.Semigroup as S
-#endif
 
 -- | Pointwise lifting of a class over two arguments, using
 -- 'Biapplicative'.


### PR DESCRIPTION
bifunctors-5.5.7 was failing to compile with older
semigroups (look at the diff why).

The corresponding revision is made for 5.5.7 on Hackage.