### PR TITLE
Allow building with template-haskell-2.17.0.0 (GHC 9.0)

### DIFF
--- a/bifunctors.cabal
+++ b/bifunctors.cabal
@@ -60,8 +60,8 @@ library
     base-orphans        >= 0.5.2 && < 1,
     comonad             >= 4     && < 6,
     containers          >= 0.1   && < 0.7,
-    template-haskell    >= 2.4   && < 2.17,
-    th-abstraction      >= 0.3   && < 0.4,
+    template-haskell    >= 2.4   && < 2.18,
+    th-abstraction      >= 0.4   && < 0.5,
     transformers        >= 0.2   && < 0.6
 
   if !impl(ghc > 8.2)

--- a/bifunctors.cabal
+++ b/bifunctors.cabal
@@ -119,6 +119,8 @@ test-suite bifunctors-spec
   main-is: Spec.hs
   other-modules: BifunctorSpec
   ghc-options: -Wall
+  if impl(ghc >= 8.6)
+    ghc-options: -Wno-star-is-type
   default-language: Haskell2010
   build-tool-depends: hspec-discover:hspec-discover >= 1.8
   build-depends:

--- a/src/Data/Bifunctor/TH.hs
+++ b/src/Data/Bifunctor/TH.hs
@@ -70,6 +70,7 @@ import qualified Data.Map as Map ((!), fromList, keys, lookup, member, size)
 import           Data.Maybe
 
 import           Language.Haskell.TH.Datatype
+import           Language.Haskell.TH.Datatype.TyVarBndr
 import           Language.Haskell.TH.Lib
 import           Language.Haskell.TH.Ppr
 import           Language.Haskell.TH.Syntax
@@ -1097,7 +1098,7 @@ data FFoldType a      -- Describes how to fold over a Type in a functor like way
           --   argument parts of @fun_ty arg_ty_1 ... arg_ty_n@.
         , ft_bad_app :: a
           -- ^ Type app, variable other than in last arguments
-        , ft_forall  :: [TyVarBndr] -> a -> a
+        , ft_forall  :: [TyVarBndrSpec] -> a -> a
           -- ^ Forall type
      }
 


### PR DESCRIPTION
This involves using `th-abstraction-0.4` or later.