### PR TITLE
Fix #89 by strategically using underscore-prefixed variable names

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,8 @@
+next [????.??.??]
+-----------------
+* Fix a bug in which `deriveBifoldable` could generate code that triggers
+  `-Wunused-matches` warnings.
+
 5.5.9 [2020.12.30]
 ------------------
 * Explicitly mark modules as Safe or Trustworthy.

--- a/bifunctors.cabal
+++ b/bifunctors.cabal
@@ -120,7 +120,7 @@ test-suite bifunctors-spec
   type: exitcode-stdio-1.0
   hs-source-dirs: tests
   main-is: Spec.hs
-  other-modules: BifunctorSpec
+  other-modules: BifunctorSpec T89Spec
   ghc-options: -Wall
   if impl(ghc >= 8.6)
     ghc-options: -Wno-star-is-type

--- a/src/Data/Bifunctor/TH.hs
+++ b/src/Data/Bifunctor/TH.hs
@@ -1211,14 +1211,30 @@ foldDataConArgs tvMap ft con = do
 -- Make a 'LamE' using a fresh variable.
 mkSimpleLam :: (Exp -> Q Exp) -> Q Exp
 mkSimpleLam lam = do
-  n <- newName "n"
+  -- Use an underscore in front of the variable name, as it's possible for
+  -- certain Bifoldable instances to generate code like this (see #89):
+  --
+  -- @
+  -- bifoldMap (\\_n -> mempty) ...
+  -- @
+  --
+  -- Without the underscore, that code would trigger -Wunused-matches warnings.
+  n <- newName "_n"
   body <- lam (VarE n)
   return $ LamE [VarP n] body
 
 -- Make a 'LamE' using two fresh variables.
 mkSimpleLam2 :: (Exp -> Exp -> Q Exp) -> Q Exp
 mkSimpleLam2 lam = do
-  n1 <- newName "n1"
+  -- Use an underscore in front of the variable name, as it's possible for
+  -- certain Bifoldable instances to generate code like this (see #89):
+  --
+  -- @
+  -- bifoldr (\\_n1 n2 -> n2) ...
+  -- @
+  --
+  -- Without the underscore, that code would trigger -Wunused-matches warnings.
+  n1 <- newName "_n1"
   n2 <- newName "n2"
   body <- lam (VarE n1) (VarE n2)
   return $ LamE [VarP n1, VarP n2] body

--- a/tests/T89Spec.hs
+++ b/tests/T89Spec.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+-- | A regression test for #89 which ensures that a TH-generated Bifoldable
+-- instance of a certain shape does not trigger -Wunused-matches warnings.
+module T89Spec where
+
+import Data.Bifunctor.TH
+import Test.Hspec
+
+data X = MkX
+data Y a b = MkY a b
+newtype XY a b = XY { getResp :: Either X (Y a b) }
+
+$(deriveBifoldable ''Y)
+$(deriveBifoldable ''XY)
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = return ()


### PR DESCRIPTION
Normally, I like to avoid using underscores in the names of TH-generated variables, as they can sometimes mask bugs in TH code generation. In the case of #89, however, it was observed that `deriveBifoldable` can genuinely generate code where one of the variables in a lambda expression is never used. This fixes #89 by prefixes those variables with an underscore to avoid the generated code from triggering `-Wunused-matches` warnings.