### PR TITLE
Revisit tuples

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -16,6 +16,10 @@
 * The instance `Enum (Data.Bifunctor.Biap a b)` has been removed as it is incompatible
   with the pointwise lifting of `Bounded`.
 * Added missing `Contravariant` instances
+* Make the `Biapplicative` instances for tuples lazy, to match the `Bifunctor`
+  instances.
+* Add `Lazier` and `Stricter` newtype wrappers to turn strict bifunctors lazy
+  and lazy ones strict.
 
 5.5.11 [2021.04.30]
 -------------------

--- a/bifunctors.cabal
+++ b/bifunctors.cabal
@@ -35,7 +35,13 @@ library
     , tagged           >= 0.8.6 && < 1
     , template-haskell
     , th-abstraction   ^>= 0.4.2.0
-    , transformers     >= 0.5 && < 0.7
+    , transformers     >= 0.6 && < 0.7
+  if(impl(ghc>=9.0.1))
+    build-depends:
+      -- We need this for Solo. Soon it will be exposed
+      -- in base, at which point we can put an upper bound
+      -- on this awful dependency.
+      , ghc-prim
 
   exposed-modules:
     Data.Biapplicative

--- a/bifunctors.cabal
+++ b/bifunctors.cabal
@@ -57,6 +57,8 @@ library
     Data.Bifunctor.TH
     Data.Bifunctor.Wrapped
     Data.Bifunctor.Yoneda
+    Data.Bifunctor.Stricter
+    Data.Bifunctor.Lazier
 
   other-modules:
     Data.Bifunctor.TH.Internal

--- a/src/Data/Biapplicative.hs
+++ b/src/Data/Biapplicative.hs
@@ -140,7 +140,7 @@ biliftA3 = \f g a b c -> biliftA2 f g a b <<*>> c
 -- implementation.
 --
 -- The types subject to rewrite rules: '[]', 'Maybe', @'Either' a@, 'Identity',
--- @'Const' a@, @'(,)' a@, @'Map.Map' k@, 'IM.IntMap', 'Seq.Seq', and 'Tree.Tree'.
+-- @'Const' a@, @(,) a@, @'Map.Map' k@, 'IM.IntMap', 'Seq.Seq', and 'Tree.Tree'.
 traverseBia :: (Traversable t, Biapplicative p)
             => (a -> p b c) -> t a -> p (t b) (t c)
 traverseBia = inline (traverseBiaWith traverse)
@@ -152,7 +152,7 @@ traverseBia = inline (traverseBiaWith traverse)
 -- versions for a few important types.
 {-# INLINABLE [1] traverseBia #-}
 
--- | Perform all the 'Biappicative' actions in a 'Traversable' container
+-- | Perform all the 'Biapplicative' actions in a 'Traversable' container
 -- and produce a container with all the results.
 --
 -- @
@@ -397,9 +397,9 @@ traverseBiaSeq f' (Seq.Seq (Seq.Deep s' pr' m' sf')) =
 instance Biapplicative (,) where
   bipure = (,)
   {-# INLINE bipure #-}
-  (f, g) <<*>> (a, b) = (f a, g b)
+  ~(f, g) <<*>> ~(a, b) = (f a, g b)
   {-# INLINE (<<*>>) #-}
-  biliftA2 f g (x, y) (a, b) = (f x a, g y b)
+  biliftA2 f g ~(x, y) ~(a, b) = (f x a, g y b)
   {-# INLINE biliftA2 #-}
 
 instance Biapplicative Arg where
@@ -413,32 +413,32 @@ instance Biapplicative Arg where
 instance Monoid x => Biapplicative ((,,) x) where
   bipure = (,,) mempty
   {-# INLINE bipure #-}
-  (x, f, g) <<*>> (x', a, b) = (mappend x x', f a, g b)
+  ~(x, f, g) <<*>> ~(x', a, b) = (mappend x x', f a, g b)
   {-# INLINE (<<*>>) #-}
 
 instance (Monoid x, Monoid y) => Biapplicative ((,,,) x y) where
   bipure = (,,,) mempty mempty
   {-# INLINE bipure #-}
-  (x, y, f, g) <<*>> (x', y', a, b) = (mappend x x', mappend y y', f a, g b)
+  ~(x, y, f, g) <<*>> ~(x', y', a, b) = (mappend x x', mappend y y', f a, g b)
   {-# INLINE (<<*>>) #-}
 
 {-
 instance (Monoid x, Monoid y, Monoid z) => Biapplicative ((,,,,) x y z) where
   bipure = (,,,,) mempty mempty mempty
   {-# INLINE bipure #-}
-  (x, y, z, f, g) <<*>> (x', y', z', a, b) = (mappend x x', mappend y y', mappend z z', f a, g b)
+  ~(x, y, z, f, g) <<*>> ~(x', y', z', a, b) = (mappend x x', mappend y y', mappend z z', f a, g b)
   {-# INLINE (<<*>>) #-}
 
 instance (Monoid x, Monoid y, Monoid z, Monoid w) => Biapplicative ((,,,,,) x y z w) where
   bipure = (,,,,,) mempty mempty mempty mempty
   {-# INLINE bipure #-}
-  (x, y, z, w, f, g) <<*>> (x', y', z', w', a, b) = (mappend x x', mappend y y', mappend z z', mappend w w', f a, g b)
+  ~(x, y, z, w, f, g) <<*>> ~(x', y', z', w', a, b) = (mappend x x', mappend y y', mappend z z', mappend w w', f a, g b)
   {-# INLINE (<<*>>) #-}
 
 instance (Monoid x, Monoid y, Monoid z, Monoid w, Monoid v) => Biapplicative ((,,,,,,) x y z w v) where
   bipure = (,,,,,,) mempty mempty mempty mempty mempty
   {-# INLINE bipure #-}
-  (x, y, z, w, v, f, g) <<*>> (x', y', z', w', v', a, b) = (mappend x x', mappend y y', mappend z z', mappend w w', mappend v v', f a, g b)
+  ~(x, y, z, w, v, f, g) <<*>> ~(x', y', z', w', v', a, b) = (mappend x x', mappend y y', mappend z z', mappend w w', mappend v v', f a, g b)
   {-# INLINE (<<*>>) #-}
 -}
 

--- a/src/Data/Bifunctor/Lazier.hs
+++ b/src/Data/Bifunctor/Lazier.hs
@@ -1,0 +1,185 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE Trustworthy #-}
+
+-- | A newtype wrapper to make lazier bifunctors.
+module Data.Bifunctor.Lazier (Lazier (..), Lazify (lazify)) where
+
+import GHC.Generics
+import Control.Applicative (Applicative (..))
+import Data.Bifunctor
+import Data.Biapplicative
+import GHC.TypeLits
+import Data.Coerce
+
+-- | Given a bifunctor @p@ with a 'Lazify' instance (typically a tuple-like
+-- type with lazy fields), produce a bifunctor whose 'Bifunctor',
+-- 'Biapplicative', 'Functor', and 'Applicative' methods are lazy in their
+-- @Lazier p a b@ argument(s).
+--
+-- For example, given
+--
+-- @
+-- data SP a b = SP a b
+--   deriving (Functor, Generic)
+--
+-- instance Bifunctor SP where
+--   bimap f g (SP a b) = SP (f a) (g b)
+-- @
+--
+-- we effectively get
+--
+-- @
+-- bimap f g ~(Lazier (SP a b)) = Lazier (SP (f a) (g b))
+-- fmap f ~(Lazier (SP a b)) = Lazier (SP a (f b))
+-- @
+--
+-- === Notes
+--
+-- If the type is a newtype, then it is required to wrap a
+-- lazy generic product type, etc.
+--
+-- We don't lazify the results of @pure@ or @bipure@. In a lazifiable
+-- bifunctor, these functions should always be lazy anyway.
+--
+-- === The details
+--
+-- The @Lazier@ arguments are "lazified" before being passed to the
+-- underlying 'Bifunctor', etc., method using 'lazify'. So
+--
+-- @
+-- 'bimap' f g (Lazier m) = Lazier ('bimap' f g ('lazify' m))
+-- 'biliftA2' f g (Lazier m) (Lazier n) = Lazier ('biliftA2' f g ('lazify' m) ('lazify' n))
+-- @
+--
+-- The default 'lazify' implementation is sufficient for simple tuple types. It
+-- does not, however, recursively lazify nested tuples, or work any sort of
+-- magic with strict fields that happen to be singletons.  To make those 
+-- sufficiently lazy, users must write overlapping instances of 'Lazify'.
+--
+-- @since 6
+newtype Lazier p a b = Lazier { unLazier :: p a b }
+  deriving (Show, Read, Eq, Ord)
+
+instance (Functor (p a), forall b. Lazify (p a b)) => Functor (Lazier p a) where
+  fmap f (Lazier x) = Lazier (fmap f (lazify x))
+  x <$ Lazier m = Lazier (x <$ lazify m)
+
+instance (Bifunctor p, forall a b. Lazify (p a b)) => Bifunctor (Lazier p) where
+  bimap f g (Lazier x) = Lazier (bimap f g (lazify x))
+  first f (Lazier x) = Lazier (first f (lazify x))
+  second g (Lazier x) = Lazier (second g (lazify x))
+
+instance (Applicative (p a), forall b. Lazify (p a b)) => Applicative (Lazier p a) where
+  pure :: forall b. b -> Lazier p a b
+  pure = coerce (pure @(p a) @b)
+
+  Lazier fs <*> Lazier xs = Lazier (lazify fs <*> lazify xs)
+  liftA2 f (Lazier xs) (Lazier ys) = Lazier (liftA2 f (lazify xs) (lazify ys))
+
+  Lazier xs *> Lazier ys = Lazier (lazify xs *> lazify ys)
+  Lazier xs <* Lazier ys = Lazier (lazify xs <* lazify ys)
+
+instance (Biapplicative p, forall a b. Lazify (p a b)) => Biapplicative (Lazier p) where
+  bipure :: forall a b. a -> b -> Lazier p a b
+  bipure = coerce (bipure @p @a @b)
+
+  Lazier fs <<*>> Lazier xs = Lazier (lazify fs <<*>> lazify xs)
+  biliftA2 f g (Lazier xs) (Lazier ys) = Lazier (biliftA2 f g (lazify xs) (lazify ys))
+
+  Lazier xs *>> Lazier ys = Lazier (lazify xs *>> lazify ys)
+  Lazier xs <<* Lazier ys = Lazier (lazify xs <<* lazify ys)
+
+-- | Tuple-like types and newtypes around such that can be made lazy.
+-- There is one instance, which works for most lazifiable types that are
+-- instances of `Generic`. In the event that you need an instance for a type
+-- for which that doesn't work, you can write an overlapping one. For example,
+--
+-- @
+-- data Baz = Beep !Void | Boop Int
+-- @
+--
+-- can't be lazified generically, but you can write
+--
+-- @
+-- instance {-\# OVERLAPPING \#-} Lazify Baz where
+--   lazify ~(Boop i) = Boop i
+-- @
+--
+-- Similarly, if a tuple has one or more strict fields, but
+-- they're all /singletons/, then a custom 'Lazify' instance can
+-- pull their values out of the air given the right constraints.
+--
+-- This can also be used to write instances for types that aren't instances
+-- of 'Generic'.
+--
+-- @since 6
+class Lazify a where
+  -- Make the value of a product type lazy. For example, for pairs,
+  -- it is (effectively) defined
+  --
+  -- @
+  -- lazify ~(a, b) = (a, b)
+  -- @
+  lazify :: a -> a
+
+instance (Generic a, GLazify a (Rep a)) => Lazify a where
+  lazify = to . glazify @a . from
+
+class GLazify a f where
+  glazify :: f p -> f p
+
+instance GLazify a f => GLazify a (D1 ('MetaData _q _r _s 'False) f) where
+  glazify (M1 m) = M1 (glazify @a m)
+instance GLazify a f => GLazify a (C1 c f) where
+  glazify (M1 m) = M1 (glazify @a m)
+instance GLazify a f => GLazify a (S1 ('MetaSel _p _q _r 'DecidedLazy) f) where
+  glazify (M1 m) = M1 (glazify @a m)
+instance TypeError ('Text "Can't lazify " ':<>: 'ShowType a ':<>: 'Text ":"
+                    ':$$: 'Text "It has a strict field.")
+  => GLazify a (S1 ('MetaSel _p _q _r 'DecidedStrict) f) where
+  glazify _ = error "Unreachable"
+instance TypeError ('Text "Can't lazify " ':<>: 'ShowType a ':<>: 'Text ":"
+                    ':$$: 'Text "It has a strict (unpacked) field.")
+  => GLazify a (S1 ('MetaSel _p _q _r 'DecidedUnpack) f) where
+  glazify _ = error "Unreachable"
+
+-- Newtypes delegate to what they wrap. In the process, we lose
+-- track of the wrapping type, so if someone writes
+--
+-- newtype Foo a b = Foo (Bar a b) deriving Generic
+-- data Bar a b = L a | R b deriving Generic
+--
+-- then lazify (Foo ...) will produce a type error about Bar rather than
+-- about Foo. This is arguably not ideal (it would be nice to get a whole
+-- explanation of what wraps what and so on), but it's necessary if users
+-- are to be able to write overlapping instances for Lazify without some
+-- additional major infrastructure.
+instance Lazify c
+  => GLazify a (D1 ('MetaData _q _r _s 'True) (C1 _t (S1 _u (K1 _v c)))) where
+  glazify (M1 (M1 (M1 (K1 x)))) = M1 (M1 (M1 (K1 (lazify x))))
+
+instance (GLazify a f, GLazify a g) => GLazify a (f :*: g) where
+  glazify ~(m :*: f) = m :*: f
+
+instance GLazify a U1 where
+  glazify ~U1 = U1
+
+instance GLazify a (K1 i c) where
+  -- These just pass through.
+  glazify x = x
+
+instance TypeError ('Text "Can't lazify " ':<>: 'ShowType a ':<>: 'Text ":"
+                    ':$$: 'Text "It is a sum type.")
+  => GLazify a (f :+: g) where
+  glazify _ = error "Unreachable"

--- a/src/Data/Bifunctor/Lazier.hs
+++ b/src/Data/Bifunctor/Lazier.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -11,16 +13,47 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE PolyKinds #-}
 
 -- | A newtype wrapper to make lazier bifunctors.
-module Data.Bifunctor.Lazier (Lazier (..), Lazify (lazify)) where
+--
+-- @since 6
+module Data.Bifunctor.Lazier
+  ( Lazier (..)
+  , Lazify (..)) where
 
 import GHC.Generics
-import Control.Applicative (Applicative (..))
+import Control.Applicative (Applicative (..), Const (..))
 import Data.Bifunctor
 import Data.Biapplicative
 import GHC.TypeLits
 import Data.Coerce
+import qualified Data.Functor.Product as Product
+import Data.Functor.Identity (Identity)
+import Data.Functor.Compose (Compose)
+import Data.Type.Equality ((:~:)(..), (:~~:)(..), type (~~))
+import Type.Reflection (Typeable, TypeRep, typeRep)
+#if MIN_VERSION_base (4,15,0)
+import GHC.Tuple (Solo (..))
+#endif
+import Data.Bifunctor.Tannen (Tannen)
+import Data.Bifunctor.Biff (Biff)
+import Data.Bifunctor.Wrapped (WrappedBifunctor)
+import Data.Bifunctor.Flip (Flip)
+import qualified Data.Bifunctor.Fix as BiFix
+import Data.Bifunctor.Joker (Joker)
+import Data.Bifunctor.Join (Join)
+import Data.Bifunctor.Clown (Clown)
+import Data.Bifunctor.Biap (Biap)
+import qualified Data.Bifunctor.Product as BiProduct
+import qualified Data.Semigroup as Semigroup
+import qualified Data.Monoid as Monoid
+import Data.Tagged (Tagged)
+import Data.Tree (Tree)
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.Functor.Reverse as FuncReverse
+import qualified Control.Applicative.Backwards as AppBackwards
+import Control.Monad.Trans.Identity (IdentityT)
 
 -- | Given a bifunctor @p@ with a 'Lazify' instance (typically a tuple-like
 -- type with lazy fields), produce a bifunctor whose 'Bifunctor',
@@ -65,7 +98,7 @@ import Data.Coerce
 -- The default 'lazify' implementation is sufficient for simple tuple types. It
 -- does not, however, recursively lazify nested tuples, or work any sort of
 -- magic with strict fields that happen to be singletons.  To make those 
--- sufficiently lazy, users must write overlapping instances of 'Lazify'.
+-- sufficiently lazy, users must write custom instances of 'Lazify'.
 --
 -- @since 6
 newtype Lazier p a b = Lazier { unLazier :: p a b }
@@ -100,11 +133,11 @@ instance (Biapplicative p, forall a b. Lazify (p a b)) => Biapplicative (Lazier 
   Lazier xs *>> Lazier ys = Lazier (lazify xs *>> lazify ys)
   Lazier xs <<* Lazier ys = Lazier (lazify xs <<* lazify ys)
 
--- | Tuple-like types and newtypes around such that can be made lazy.
--- There is one instance, which works for most lazifiable types that are
+-- | Tuple-like types and newtypes around such that can be made lazy.  There is
+-- a default implementation which works for most lazifiable types that are
 -- instances of `Generic`. In the event that you need an instance for a type
--- for which that doesn't work, you can write an overlapping one. For example,
---
+-- for which that doesn't work, you can write a custom one. For example,
+
 -- @
 -- data Baz = Beep !Void | Boop Int
 -- @
@@ -112,16 +145,13 @@ instance (Biapplicative p, forall a b. Lazify (p a b)) => Biapplicative (Lazier 
 -- can't be lazified generically, but you can write
 --
 -- @
--- instance {-\# OVERLAPPING \#-} Lazify Baz where
+-- instance Lazify Baz where
 --   lazify ~(Boop i) = Boop i
 -- @
 --
 -- Similarly, if a tuple has one or more strict fields, but
 -- they're all /singletons/, then a custom 'Lazify' instance can
 -- pull their values out of the air given the right constraints.
---
--- This can also be used to write instances for types that aren't instances
--- of 'Generic'.
 --
 -- @since 6
 class Lazify a where
@@ -132,9 +162,17 @@ class Lazify a where
   -- lazify ~(a, b) = (a, b)
   -- @
   lazify :: a -> a
-
-instance (Generic a, GLazify a (Rep a)) => Lazify a where
+  default lazify :: (Generic a, GLazify a (Rep a)) => a -> a
   lazify = to . glazify @a . from
+
+instance a ~ b => Lazify (a :~: b) where
+  lazify _ = Refl
+instance a ~~ b => Lazify (a :~~: b) where
+  lazify _ = HRefl
+instance Typeable a => Lazify (TypeRep a) where
+  lazify _ = typeRep
+
+-- Boring, generic-derived instances are at the bottom.
 
 class GLazify a f where
   glazify :: f p -> f p
@@ -163,8 +201,8 @@ instance TypeError ('Text "Can't lazify " ':<>: 'ShowType a ':<>: 'Text ":"
 -- then lazify (Foo ...) will produce a type error about Bar rather than
 -- about Foo. This is arguably not ideal (it would be nice to get a whole
 -- explanation of what wraps what and so on), but it's necessary if users
--- are to be able to write overlapping instances for Lazify without some
--- additional major infrastructure.
+-- are to be able to write custom instances for Lazify without some
+-- additional major infrastructure and likely user pain.
 instance Lazify c
   => GLazify a (D1 ('MetaData _q _r _s 'True) (C1 _t (S1 _u (K1 _v c)))) where
   glazify (M1 (M1 (M1 (K1 x)))) = M1 (M1 (M1 (K1 (lazify x))))
@@ -183,3 +221,49 @@ instance TypeError ('Text "Can't lazify " ':<>: 'ShowType a ':<>: 'Text ":"
                     ':$$: 'Text "It is a sum type.")
   => GLazify a (f :+: g) where
   glazify _ = error "Unreachable"
+
+-- Derived instances
+
+instance Lazify ()
+#if MIN_VERSION_base (4,15,0)
+instance Lazify (Solo a)
+#endif
+instance Lazify (a, b)
+instance Lazify (a, b, c)
+instance Lazify (a, b, c, d)
+instance Lazify (a, b, c, d, e)
+instance Lazify (a, b, c, d, e, f)
+instance Lazify (a, b, c, d, e, f, g)
+instance Lazify (Product.Product f g a)
+instance Lazify (BiProduct.Product f g a b)
+instance Lazify (Semigroup.Arg a b)
+instance Lazify (NonEmpty a)
+instance Lazify (Tree a)
+instance Lazify a => Lazify (Identity a)
+instance Lazify a => Lazify (Const a b)
+instance Lazify b => Lazify (Tagged a b)
+instance Lazify (f (g a)) => Lazify (Compose f g a)
+instance Lazify ((f :*: g) a)
+instance Lazify (f (g a)) => Lazify ((f :.: g) a)
+instance Lazify (p a b) => Lazify (WrappedBifunctor p a b)
+instance Lazify (f (p a b)) => Lazify (Tannen f p a b)
+instance Lazify (f a) => Lazify (Clown f a b)
+instance Lazify (g b) => Lazify (Joker g a b)
+instance Lazify (p a a) => Lazify (Join p a)
+instance Lazify (p b a) => Lazify (Flip p a b)
+instance Lazify (p (BiFix.Fix p a) a) => Lazify (BiFix.Fix p a)
+instance Lazify (p (f a) (g b)) => Lazify (Biff p f g a b)
+instance Lazify (bi a b) => Lazify (Biap bi a b)
+instance Lazify a => Lazify (Semigroup.Product a)
+instance Lazify a => Lazify (Semigroup.Sum a)
+instance Lazify a => Lazify (Semigroup.Dual a)
+instance Lazify a => Lazify (Semigroup.WrappedMonoid a)
+instance Lazify a => Lazify (Semigroup.Last a)
+instance Lazify a => Lazify (Semigroup.First a)
+instance Lazify a => Lazify (Semigroup.Min a)
+instance Lazify a => Lazify (Semigroup.Max a)
+instance Lazify (f a) => Lazify (Monoid.Alt f a)
+instance Lazify (f a) => Lazify (Monoid.Ap f a)
+instance Lazify (t a) => Lazify (FuncReverse.Reverse t a)
+instance Lazify (f a) => Lazify (AppBackwards.Backwards f a)
+instance Lazify (f a) => Lazify (IdentityT f a)

--- a/src/Data/Bifunctor/Stricter.hs
+++ b/src/Data/Bifunctor/Stricter.hs
@@ -5,7 +5,11 @@
 {-# LANGUAGE Trustworthy #-}
 
 -- | A newtype wrapper to make stricter bifunctors.
-module Data.Bifunctor.Stricter where
+--
+-- @since 6
+module Data.Bifunctor.Stricter
+  ( Stricter (..)
+  ) where
 import Data.Bifunctor
 import Data.Biapplicative
 import Control.Applicative (Applicative (..))

--- a/src/Data/Bifunctor/Stricter.hs
+++ b/src/Data/Bifunctor/Stricter.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE Trustworthy #-}
+
+-- | A newtype wrapper to make stricter bifunctors.
+module Data.Bifunctor.Stricter where
+import Data.Bifunctor
+import Data.Biapplicative
+import Control.Applicative (Applicative (..))
+import Data.Coerce
+
+-- | Given a bifunctor @f@, produce a bifunctor whose 'Bifunctor',
+-- 'Biapplicative', 'Functor', and 'Applicative' methods are strict
+-- in their @f a b@ argument(s).
+--
+-- For example, we effectively have
+--
+-- @
+-- instance 'Bifunctor' (Stricter (,)) where
+--   'bimap' f g (a, b) = (f a, g b)
+-- @
+--
+-- ### Note
+--
+-- This may give unexpected results for "bare" newtypes, whose natural
+-- instances are in fact lazy. For example,
+--
+-- @Stricter (Const (const 3)) <<*>> undefined = undefined@
+--
+-- @since 6
+newtype Stricter f a b = Stricter { unStricter :: f a b }
+  deriving (Eq, Ord, Show)
+
+instance Functor (f a) => Functor (Stricter f a) where
+  fmap f (Stricter !m) = Stricter (fmap f m)
+  x <$ (Stricter !m) = Stricter (x <$ m)
+
+instance Applicative (f a) => Applicative (Stricter f a) where
+  pure :: forall b. b -> Stricter f a b
+  pure = coerce (pure :: b -> f a b)
+
+  Stricter (!fs) <*> Stricter (!xs) = Stricter (fs <*> xs)
+  liftA2 f (Stricter (!xs)) (Stricter (!ys)) = Stricter (liftA2 f xs ys)
+
+  Stricter (!xs) *> Stricter (!ys) = Stricter (xs *> ys)
+  Stricter (!xs) <* Stricter (!ys) = Stricter (xs <* ys)
+
+instance Bifunctor f => Bifunctor (Stricter f) where
+  bimap f g !(Stricter m) = Stricter (bimap f g m)
+  first f !(Stricter m) = Stricter (first f m)
+  second g !(Stricter m) = Stricter (second g m)
+
+instance Biapplicative f => Biapplicative (Stricter f) where
+  bipure :: forall a b. a -> b -> Stricter f a b
+  bipure = coerce (bipure :: a -> b -> f a b)
+
+  Stricter (!fs) <<*>> Stricter (!as) = Stricter (fs <<*>> as)
+  biliftA2 f g !(Stricter xs) !(Stricter ys) = Stricter (biliftA2 f g xs ys)
+
+  Stricter (!xs) *>> Stricter (!ys) = Stricter (xs *>> ys)
+  Stricter (!xs) <<* Stricter (!ys) = Stricter (xs <<* ys)


### PR DESCRIPTION
* Previously, `<<*>>` and `biliftA2` were strict in their tuple
  arguments. Unfortunately, the `Bifunctor` instances (defined
  in `base`), are *lazy* in their tuple arguments. This inconsistency
  made tuples utterly useless for `Biapplicative` traversals.
  Make `<<*>>` and `biliftA2` lazy for tuples.

* Add `Stricter` and `Lazier` newtype wrappers. `Stricter` produces
  strict `Functor`, `Applicative`, `Bifunctor`, and `Biapplicative`
  instances from (possibly) lazy ones. `Lazier` produces lazy
  instances from (possibly) strict ones for product types, using
  `GHC.Generics`.