### PR TITLE
Make Biapplicative instances for tuples lazy

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -16,6 +16,8 @@
 * The instance `Enum (Data.Bifunctor.Biap a b)` has been removed as it is incompatible
   with the pointwise lifting of `Bounded`.
 * Added missing `Contravariant` instances
+* Make the `Biapplicative` instances for tuples lazy, to match their `Bifunctor`
+  instances.
 
 5.5.11 [2021.04.30]
 -------------------

--- a/src/Data/Biapplicative.hs
+++ b/src/Data/Biapplicative.hs
@@ -397,9 +397,9 @@ traverseBiaSeq f' (Seq.Seq (Seq.Deep s' pr' m' sf')) =
 instance Biapplicative (,) where
   bipure = (,)
   {-# INLINE bipure #-}
-  (f, g) <<*>> (a, b) = (f a, g b)
+  ~(f, g) <<*>> ~(a, b) = (f a, g b)
   {-# INLINE (<<*>>) #-}
-  biliftA2 f g (x, y) (a, b) = (f x a, g y b)
+  biliftA2 f g ~(x, y) ~(a, b) = (f x a, g y b)
   {-# INLINE biliftA2 #-}
 
 instance Biapplicative Arg where
@@ -413,32 +413,32 @@ instance Biapplicative Arg where
 instance Monoid x => Biapplicative ((,,) x) where
   bipure = (,,) mempty
   {-# INLINE bipure #-}
-  (x, f, g) <<*>> (x', a, b) = (mappend x x', f a, g b)
+  ~(x, f, g) <<*>> ~(x', a, b) = (mappend x x', f a, g b)
   {-# INLINE (<<*>>) #-}
 
 instance (Monoid x, Monoid y) => Biapplicative ((,,,) x y) where
   bipure = (,,,) mempty mempty
   {-# INLINE bipure #-}
-  (x, y, f, g) <<*>> (x', y', a, b) = (mappend x x', mappend y y', f a, g b)
+  ~(x, y, f, g) <<*>> ~(x', y', a, b) = (mappend x x', mappend y y', f a, g b)
   {-# INLINE (<<*>>) #-}
 
 {-
 instance (Monoid x, Monoid y, Monoid z) => Biapplicative ((,,,,) x y z) where
   bipure = (,,,,) mempty mempty mempty
   {-# INLINE bipure #-}
-  (x, y, z, f, g) <<*>> (x', y', z', a, b) = (mappend x x', mappend y y', mappend z z', f a, g b)
+  ~(x, y, z, f, g) <<*>> ~(x', y', z', a, b) = (mappend x x', mappend y y', mappend z z', f a, g b)
   {-# INLINE (<<*>>) #-}
 
 instance (Monoid x, Monoid y, Monoid z, Monoid w) => Biapplicative ((,,,,,) x y z w) where
   bipure = (,,,,,) mempty mempty mempty mempty
   {-# INLINE bipure #-}
-  (x, y, z, w, f, g) <<*>> (x', y', z', w', a, b) = (mappend x x', mappend y y', mappend z z', mappend w w', f a, g b)
+  ~(x, y, z, w, f, g) <<*>> ~(x', y', z', w', a, b) = (mappend x x', mappend y y', mappend z z', mappend w w', f a, g b)
   {-# INLINE (<<*>>) #-}
 
 instance (Monoid x, Monoid y, Monoid z, Monoid w, Monoid v) => Biapplicative ((,,,,,,) x y z w v) where
   bipure = (,,,,,,) mempty mempty mempty mempty mempty
   {-# INLINE bipure #-}
-  (x, y, z, w, v, f, g) <<*>> (x', y', z', w', v', a, b) = (mappend x x', mappend y y', mappend z z', mappend w w', mappend v v', f a, g b)
+  ~(x, y, z, w, v, f, g) <<*>> ~(x', y', z', w', v', a, b) = (mappend x x', mappend y y', mappend z z', mappend w w', mappend v v', f a, g b)
   {-# INLINE (<<*>>) #-}
 -}
 


### PR DESCRIPTION
Previously, `<<*>>` and `biliftA2` were strict in their tuple
arguments. Unfortunately, the `Bifunctor` instances (defined
in `base`), are *lazy* in their tuple arguments. This inconsistency
made tuples utterly useless for `Biapplicative` traversals.
Make `<<*>>` and `biliftA2` lazy for tuples.