### PR TITLE
Revamp instances

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -18,6 +18,23 @@
 * Added missing `Contravariant` instances
 * Make the `Biapplicative` instances for tuples lazy, to match their `Bifunctor`
   instances.
+* Add `Data.Biapplicative.Backwards` and `Data.Bifunctor.Reverse` as analogues
+  of `Control.Applicative.Backwards` and `Data.Functor.Reverse`.
+* Add `TestEquality` and `TestCoercion` instances for relevant types.
+* Change all `Show`, `Show1`, and `Show2` instances for newtypes to plain syntax
+  rather than record syntax, and make all their `Read`, `Read1`, and `Read2`
+  instances flexible, so they'll accept either plain or record syntax. Consolidate
+  almost all reading and showing details in a single internal module.
+* Make instances use `FlexibleContexts` instead of `Show2`, `Eq2`, etc., with certain
+  exceptions for the `WrappedBifunctor` type.
+* Add `liftYoneda`, `lowerYoneda`, `liftCoyoneda`, and `lowerCoyoneda`. Use these
+  to add many basic instances for `Yoneda` and `Coyoneda`.
+* Add numerous basic instances for `Data.Bifunctor.Functor.Fix`.
+* Slightly clarify/improve the `Biapplicative` instance for `Joker`.
+* Make `bifoldr` for `Joker` use `foldl` and `bifoldr` use `foldr`. Do the
+  same for `Clown`.
+* Make the `Functor` instance for `Coyoneda` do the obvious `Coyoneda`
+  thing.
 
 5.5.11 [2021.04.30]
 -------------------

--- a/bifunctors.cabal
+++ b/bifunctors.cabal
@@ -63,6 +63,7 @@ library
   other-modules:
     Data.Bifunctor.TH.Internal
     Data.Bifunctor.Unsafe
+    Data.Bifunctor.ShowRead
     Paths_bifunctors
 
   autogen-modules:

--- a/src/Data/Bifunctor/Biap.hs
+++ b/src/Data/Bifunctor/Biap.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE Trustworthy #-}
@@ -24,6 +25,7 @@ import qualified Control.Monad.Fail as Fail (MonadFail)
 import Data.Biapplicative
 import Data.Bifunctor
 import Data.Bifunctor.Functor
+import Data.Bifunctor.ShowRead
 import Data.Bifunctor.Unsafe
 import Data.Bifoldable
 import Data.Bitraversable
@@ -68,8 +70,6 @@ newtype Biap bi a b = Biap { getBiap :: bi a b }
   deriving stock
   ( Eq
   , Ord
-  , Show
-  , Read
   , Functor
   , Foldable
   , Traversable
@@ -91,8 +91,6 @@ newtype Biap bi a b = Biap { getBiap :: bi a b }
   , Eq2
   , Ord2
   )
-
--- TODO: Show1, Show2, Read1, Read2
 
 instance BifunctorFunctor Biap where
   bifmap f = Biap #. f .# getBiap
@@ -200,3 +198,17 @@ instance
   {-# inline log1pexp #-}
   {-# inline log1mexp #-}
 
+deriving via ShowRead (Biap p a b) instance Show (p a b) => Show (Biap p a b)
+
+deriving via ShowRead1 (Biap p a) instance Show1 (p a) => Show1 (Biap p a)
+
+deriving via ShowRead2 (Biap p) instance Show2 p => Show2 (Biap p)
+
+-- | Accepts either plain or record syntax.
+deriving via ShowRead (Biap p a b) instance Read (p a b) => Read (Biap p a b)
+
+-- | Accepts either plain or record syntax.
+deriving via ShowRead1 (Biap p a) instance Read1 (p a) => Read1 (Biap p a)
+
+-- | Accepts either plain or record syntax.
+deriving via ShowRead2 (Biap p) instance Read2 p => Read2 (Biap p)

--- a/src/Data/Bifunctor/Biap.hs
+++ b/src/Data/Bifunctor/Biap.hs
@@ -31,6 +31,8 @@ import Data.Bifoldable
 import Data.Bitraversable
 -- import Data.Bifunctor.Classes
 import Data.Functor.Classes
+import Data.Type.Equality
+import Data.Type.Coercion
 import GHC.Generics
 import qualified Data.Semigroup as S
 import Numeric
@@ -90,6 +92,8 @@ newtype Biap bi a b = Biap { getBiap :: bi a b }
   , Bifoldable
   , Eq2
   , Ord2
+  , TestEquality
+  , TestCoercion
   )
 
 instance BifunctorFunctor Biap where

--- a/src/Data/Bifunctor/Biff.hs
+++ b/src/Data/Bifunctor/Biff.hs
@@ -40,14 +40,14 @@ deriving stock instance (Functor (p (f a)), Functor g) => Functor (Biff p f g a)
 deriving stock instance (Foldable (p (f a)), Foldable g) => Foldable (Biff p f g a)
 deriving stock instance (Traversable (p (f a)), Traversable g) => Traversable (Biff p f g a)
 
-instance (Eq2 p, Eq1 f, Eq1 g, Eq a) => Eq1 (Biff p f g a) where
-  liftEq = liftEq2 (==)
+instance (Eq1 (p (f a)), Eq1 g) => Eq1 (Biff p f g a) where
+  liftEq eq (Biff x) (Biff y) = liftEq (liftEq eq) x y
 
 instance (Eq2 p, Eq1 f, Eq1 g) => Eq2 (Biff p f g) where
   liftEq2 f g (Biff x) (Biff y) = liftEq2 (liftEq f) (liftEq g) x y
 
-instance (Ord2 p, Ord1 f, Ord1 g, Ord a) => Ord1 (Biff p f g a) where
-  liftCompare = liftCompare2 compare
+instance (Ord1 (p (f a)), Ord1 g) => Ord1 (Biff p f g a) where
+  liftCompare cmp (Biff x) (Biff y) = liftCompare (liftCompare cmp) x y
 
 instance (Ord2 p, Ord1 f, Ord1 g) => Ord2 (Biff p f g) where
   liftCompare2 f g (Biff x) (Biff y) = liftCompare2 (liftCompare f) (liftCompare g) x y

--- a/src/Data/Bifunctor/Clown.hs
+++ b/src/Data/Bifunctor/Clown.hs
@@ -110,6 +110,10 @@ instance Applicative f => Biapplicative (Clown f) where
 instance Foldable f => Bifoldable (Clown f) where
   bifoldMap f _ = foldMap f .# runClown
   {-# INLINE bifoldMap #-}
+  bifoldr c1 _c2 n = foldr c1 n .# runClown
+  {-# INLINE bifoldr #-}
+  bifoldl c1 _c2 n = foldl c1 n .# runClown
+  {-# INLINE bifoldl #-}
 
 instance Foldable (Clown f a) where
   foldMap _ = mempty

--- a/src/Data/Bifunctor/Clown.hs
+++ b/src/Data/Bifunctor/Clown.hs
@@ -23,47 +23,58 @@ import Data.Coerce
 import Data.Biapplicative
 import Data.Bifoldable
 import Data.Bifunctor
+import Data.Bifunctor.ShowRead
 import Data.Bifunctor.Unsafe
 import Data.Bitraversable
 import Data.Functor.Contravariant
 import Data.Data
 import Data.Functor.Classes
 import GHC.Generics
+import Text.Read (Read (..), readListPrecDefault)
 
 -- | Make a 'Functor' over the first argument of a 'Bifunctor'.
 --
 -- Mnemonic: C__l__owns to the __l__eft (parameter of the Bifunctor),
 --           joke__r__s to the __r__ight.
 newtype Clown f a b = Clown { runClown :: f a }
-  deriving (Eq, Ord, Show, Read, Data, Generic, Generic1)
+  deriving (Eq, Ord, Data, Generic, Generic1)
 
-instance (Eq1 f, Eq a) => Eq1 (Clown f a) where
-  liftEq = liftEq2 (==)
+instance Eq (f a) => Eq1 (Clown f a) where
+  liftEq _eq = eqClown (==)
   {-# inline liftEq #-}
 
 instance Eq1 f => Eq2 (Clown f) where
   liftEq2 = \f _ -> eqClown (liftEq f)
   {-# inline liftEq2 #-}
 
-instance (Ord1 f, Ord a) => Ord1 (Clown f a) where
-  liftCompare = liftCompare2 compare
+instance Ord (f a) => Ord1 (Clown f a) where
+  liftCompare _cmp = compareClown compare
   {-# inline liftCompare #-}
 
 instance Ord1 f => Ord2 (Clown f) where
   liftCompare2 = \f _ -> compareClown (liftCompare f)
   {-# inline liftCompare2 #-}
 
-instance (Read1 f, Read a) => Read1 (Clown f a) where
-  liftReadsPrec = liftReadsPrec2 readsPrec readList
+instance Read (f a) => Read (Clown f a b) where
+  readPrec = liftReadPrecWhatever readPrec
+  readListPrec = readListPrecDefault
+
+instance Show (f a) => Show (Clown f a b) where
+  showsPrec = liftShowsPrecWhatever showsPrec
+
+instance Read (f a) => Read1 (Clown f a) where
+  liftReadPrec _ _ = liftReadPrecWhatever readPrec
+  liftReadListPrec = liftReadListPrecDefault
+
+instance Show (f a) => Show1 (Clown f a) where
+  liftShowsPrec _ _ = liftShowsPrecWhatever showsPrec
 
 instance Read1 f => Read2 (Clown f) where
-  liftReadsPrec2 rp1 rl1 _ _ = readsPrecClown (liftReadsPrec rp1 rl1)
-
-instance (Show1 f, Show a) => Show1 (Clown f a) where
-  liftShowsPrec = liftShowsPrec2 showsPrec showList
+  liftReadPrec2 rp rl _ _ = liftReadPrecWhatever (liftReadPrec rp rl)
+  liftReadListPrec2 = liftReadListPrec2Default
 
 instance Show1 f => Show2 (Clown f) where
-  liftShowsPrec2 sp1 sl1 _ _ = showsPrecClown (liftShowsPrec sp1 sl1)
+  liftShowsPrec2 sp sl _ _ = liftShowsPrecWhatever (liftShowsPrec sp sl)
 
 eqClown :: (f a1 -> f a2 -> Bool)
         -> Clown f a1 b1 -> Clown f a2 b2 -> Bool
@@ -72,25 +83,6 @@ eqClown = coerce
 compareClown :: (f a1 -> f a2 -> Ordering)
              -> Clown f a1 b1 -> Clown f a2 b2 -> Ordering
 compareClown = coerce
-
-readsPrecClown :: (Int -> ReadS (f a))
-               -> Int -> ReadS (Clown f a b)
-readsPrecClown rpA p =
-  readParen (p > 10) $ \s0 -> do
-    ("Clown",    s1) <- lex s0
-    ("{",        s2) <- lex s1
-    ("runClown", s3) <- lex s2
-    (x,          s4) <- rpA 0 s3
-    ("}",        s5) <- lex s4
-    return (Clown x, s5)
-
-showsPrecClown :: (Int -> f a -> ShowS)
-               -> Int -> Clown f a b -> ShowS
-showsPrecClown spA p (Clown x) =
-  showParen (p > 10) $
-      showString "Clown {runClown = "
-    . spA 0 x
-    . showChar '}'
 
 instance Functor f => Bifunctor (Clown f) where
   first = \f -> Clown #. fmap f .# runClown

--- a/src/Data/Bifunctor/Flip.hs
+++ b/src/Data/Bifunctor/Flip.hs
@@ -31,7 +31,7 @@ newtype Flip p a b = Flip { runFlip :: p b a }
   deriving ( Eq, Ord
            , Generic, Data
            )
-  deriving ( Show, Read) via ShowRead (Flip p a b)
+  deriving (Show, Read) via ShowRead (Flip p a b)
 
 instance (Eq2 p, Eq a) => Eq1 (Flip p a) where
   liftEq = liftEq2 (==)

--- a/src/Data/Bifunctor/Flip.hs
+++ b/src/Data/Bifunctor/Flip.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE Safe #-}
 {-# LANGUAGE PolyKinds #-}
 
@@ -17,17 +18,20 @@ module Data.Bifunctor.Flip
 import Data.Biapplicative
 import Data.Bifoldable
 import Data.Bifunctor
+import Data.Bifunctor.ShowRead
 import Data.Bifunctor.Functor
 import Data.Bitraversable
 import Data.Data
 import Data.Functor.Classes
 import GHC.Generics
+import Text.Read (Read (..))
 
 -- | Make a 'Bifunctor' flipping the arguments of a 'Bifunctor'.
 newtype Flip p a b = Flip { runFlip :: p b a }
-  deriving ( Eq, Ord, Show, Read
+  deriving ( Eq, Ord
            , Generic, Data
            )
+  deriving ( Show, Read) via ShowRead (Flip p a b)
 
 instance (Eq2 p, Eq a) => Eq1 (Flip p a) where
   liftEq = liftEq2 (==)
@@ -40,23 +44,18 @@ instance Ord2 p => Ord2 (Flip p) where
   liftCompare2 f g (Flip x) (Flip y) = liftCompare2 g f x y
 
 instance (Read2 p, Read a) => Read1 (Flip p a) where
-  liftReadsPrec = liftReadsPrec2 readsPrec readList
+  liftReadPrec = liftReadPrec2 readPrec readListPrec
+  liftReadListPrec = liftReadListPrecDefault
 instance Read2 p => Read2 (Flip p) where
-  liftReadsPrec2 rp1 rl1 rp2 rl2 p = readParen (p > 10) $ \s0 -> do
-    ("Flip",    s1) <- lex s0
-    ("{",       s2) <- lex s1
-    ("runFlip", s3) <- lex s2
-    (x,         s4) <- liftReadsPrec2 rp2 rl2 rp1 rl1 0 s3
-    ("}",       s5) <- lex s4
-    return (Flip x, s5)
-
+  liftReadPrec2 rp1 rl1 rp2 rl2 =
+    liftReadPrecWhatever (liftReadPrec2 rp2 rl2 rp1 rl1)
+  liftReadListPrec2 = liftReadListPrec2Default
 instance (Show2 p, Show a) => Show1 (Flip p a) where
   liftShowsPrec = liftShowsPrec2 showsPrec showList
+
 instance Show2 p => Show2 (Flip p) where
-  liftShowsPrec2 sp1 sl1 sp2 sl2 p (Flip x) = showParen (p > 10) $
-      showString "Flip {runFlip = "
-    . liftShowsPrec2 sp2 sl2 sp1 sl1 0 x
-    . showChar '}'
+  liftShowsPrec2 sp1 sl1 sp2 sl2 =
+    liftShowsPrecWhatever $ liftShowsPrec2 sp2 sl2 sp1 sl1
 
 instance Bifunctor p => Bifunctor (Flip p) where
   first f = Flip . second f . runFlip
@@ -76,6 +75,9 @@ instance Biapplicative p => Biapplicative (Flip p) where
 
   Flip fg <<*>> Flip xy = Flip (fg <<*>> xy)
   {-# INLINE (<<*>>) #-}
+
+  biliftA2 f g (Flip xy) (Flip ab) = Flip $ biliftA2 g f xy ab
+  {-# INLINE biliftA2 #-}
 
 instance Bifoldable p => Bifoldable (Flip p) where
   bifoldMap f g = bifoldMap g f . runFlip

--- a/src/Data/Bifunctor/Functor/Fix.hs
+++ b/src/Data/Bifunctor/Functor/Fix.hs
@@ -3,10 +3,11 @@
 {-# Language DeriveDataTypeable #-}
 {-# Language DeriveGeneric #-}
 {-# Language DeriveTraversable #-}
-{-# Language DerivingStrategies #-}
+{-# Language DerivingVia #-}
 {-# Language ScopedTypeVariables #-}
 {-# Language StandaloneDeriving #-}
 {-# Language InstanceSigs #-}
+{-# Language GeneralizedNewtypeDeriving #-}
 {-# Language Trustworthy #-}
 {-# Language QuantifiedConstraints #-}
 {-# Language UndecidableInstances #-}
@@ -21,16 +22,21 @@ module Data.Bifunctor.Functor.Fix
 import Data.Coerce
 import Data.Data
 import Data.Bifunctor
+import Data.Bifunctor.ShowRead
 import Data.Bifunctor.Functor
+import Data.Functor.Classes
 import GHC.Generics
+import Data.Type.Equality (TestEquality)
+import Data.Type.Coercion (TestCoercion)
 
 -- Fix :: ((k1 -> k2 -> *) -> k1 -> k2 -> *) -> k1 -> k2 -> *
 newtype Fix f a b = In
   { out :: f (Fix f) a b
-  } deriving (Generic, Generic1)
+  }
+  deriving stock (Generic, Generic1)
 
-deriving stock instance Functor (f (Fix f) a) => Functor (Fix f a)
-deriving stock instance Foldable (f (Fix f) a) => Foldable (Fix f a)
+deriving newtype instance Functor (f (Fix f) a) => Functor (Fix f a)
+deriving newtype instance Foldable (f (Fix f) a) => Foldable (Fix f a)
 deriving stock instance Traversable (f (Fix f) a) => Traversable (Fix f a)
 deriving stock instance 
   ( Data (f (Fix f) a b)
@@ -40,6 +46,20 @@ deriving stock instance
   , Typeable a
   , Typeable b
   ) => Data (Fix f (a :: i) (b :: j))
+deriving via ShowRead (Fix f a b) instance Show (f (Fix f) a b) => Show (Fix f a b)
+deriving via ShowRead (Fix f a b) instance Read (f (Fix f) a b) => Read (Fix f a b)
+deriving via ShowRead1 (Fix f a) instance Show1 (f (Fix f) a) => Show1 (Fix f a)
+deriving via ShowRead1 (Fix f a) instance Read1 (f (Fix f) a) => Read1 (Fix f a)
+deriving via ShowRead2 (Fix f) instance Show2 (f (Fix f)) => Show2 (Fix f)
+deriving via ShowRead2 (Fix f) instance Read2 (f (Fix f)) => Read2 (Fix f)
+deriving newtype instance Eq (f (Fix f) a b) => Eq (Fix f a b)
+deriving newtype instance Ord (f (Fix f) a b) => Ord (Fix f a b)
+deriving newtype instance Eq1 (f (Fix f) a) => Eq1 (Fix f a)
+deriving newtype instance Ord1 (f (Fix f) a) => Ord1 (Fix f a)
+deriving newtype instance Eq2 (f (Fix f)) => Eq2 (Fix f)
+deriving newtype instance Ord2 (f (Fix f)) => Ord2 (Fix f)
+deriving newtype instance TestEquality (f (Fix f) a) => TestEquality (Fix f a)
+deriving newtype instance TestCoercion (f (Fix f) a) => TestCoercion (Fix f a)
 
 -- #if __GLASGOW_HASKELL__ >= 900
 instance BifunctorFunctor f => Bifunctor (Fix f) where

--- a/src/Data/Bifunctor/Joker.hs
+++ b/src/Data/Bifunctor/Joker.hs
@@ -1,7 +1,12 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE Trustworthy #-}
 
 -- |
@@ -18,7 +23,9 @@ module Data.Bifunctor.Joker
 ( Joker(..)
 ) where
 
+import Control.Applicative (Applicative (..))
 import Data.Bifunctor
+import Data.Bifunctor.ShowRead
 import Data.Bifunctor.Unsafe
 import Data.Biapplicative
 import Data.Bifoldable
@@ -33,7 +40,8 @@ import GHC.Generics
 -- Mnemonic: C__l__owns to the __l__eft (parameter of the Bifunctor),
 --           joke__r__s to the __r__ight.
 newtype Joker g a b = Joker { runJoker :: g b }
-  deriving ( Eq, Ord, Show, Read, Data
+  deriving ( Eq, Ord, Data
+           , Foldable, Traversable
            , Generic
            , Generic1
            )
@@ -54,17 +62,22 @@ instance Ord1 g => Ord2 (Joker g) where
   liftCompare2 _ = compareJoker #. liftCompare
   {-# inline liftCompare2 #-}
 
-instance Read1 g => Read1 (Joker g a) where
-  liftReadsPrec rp rl = readsPrecJoker (liftReadsPrec rp rl)
+deriving via ShowRead (Joker g a b) instance Show (g b) => Show (Joker g a b)
+
+deriving via ShowRead1 (Joker g a) instance Show1 g => Show1 (Joker g a)
+
+-- | Accepts either plain or record syntax.
+deriving via ShowRead (Joker g a b) instance Read (g b) => Read (Joker g a b)
+
+-- | Accepts either plain or record syntax.
+deriving via ShowRead1 (Joker g a) instance Read1 g => Read1 (Joker g a)
 
 instance Read1 g => Read2 (Joker g) where
-  liftReadsPrec2 _ _ rp2 rl2 = readsPrecJoker (liftReadsPrec rp2 rl2)
-
-instance Show1 g => Show1 (Joker g a) where
-  liftShowsPrec sp sl = showsPrecJoker (liftShowsPrec sp sl)
+  liftReadPrec2 _ _ rp2 rl2 = liftReadPrecWhatever $ liftReadPrec rp2 rl2
+  liftReadListPrec2 = liftReadListPrec2Default
 
 instance Show1 g => Show2 (Joker g) where
-  liftShowsPrec2 _ _ sp2 sl2 = showsPrecJoker (liftShowsPrec sp2 sl2)
+  liftShowsPrec2 _ _ sp2 sl2 = liftShowsPrecWhatever $ liftShowsPrec sp2 sl2
 
 eqJoker :: (g b1 -> g b2 -> Bool)
         -> Joker g a1 b1 -> Joker g a2 b2 -> Bool
@@ -75,25 +88,6 @@ compareJoker :: (g b1 -> g b2 -> Ordering)
              -> Joker g a1 b1 -> Joker g a2 b2 -> Ordering
 compareJoker = coerce
 {-# inline compareJoker #-}
-
-readsPrecJoker :: (Int -> ReadS (g b))
-               -> Int -> ReadS (Joker g a b)
-readsPrecJoker rpB p =
-  readParen (p > 10) $ \s0 -> do
-    ("Joker",    s1) <- lex s0
-    ("{",        s2) <- lex s1
-    ("runJoker", s3) <- lex s2
-    (x,          s4) <- rpB 0 s3
-    ("}",        s5) <- lex s4
-    return (Joker x, s5)
-
-showsPrecJoker :: (Int -> g b -> ShowS)
-               -> Int -> Joker g a b -> ShowS
-showsPrecJoker spB p (Joker x) =
-  showParen (p > 10) $
-      showString "Joker {runJoker = "
-    . spB 0 x
-    . showChar '}'
 
 instance Functor g => Bifunctor (Joker g) where
   first _ = Joker #. runJoker
@@ -111,21 +105,23 @@ instance Applicative g => Biapplicative (Joker g) where
   bipure _ = Joker #. pure
   {-# inline bipure #-}
 
-  (<<*>>) = \ mf -> Joker #. (<*>) (runJoker mf) .# runJoker
+  (<<*>>) :: forall a b c d. Joker g (a -> b) (c -> d) -> Joker g a c -> Joker g b d
+  (<<*>>) = coerce ((<*>) :: g (c -> d) -> g c -> g d)
   {-# inline (<<*>>) #-}
+
+  biliftA2 :: forall a b c d e f. (a -> b -> c) -> (d -> e -> f) -> Joker g a d -> Joker g b e -> Joker g c f
+  biliftA2 _ = coerce (liftA2 :: (d -> e -> f) -> g d -> g e -> g f)
 
 instance Foldable g => Bifoldable (Joker g) where
   bifoldMap _ g = foldMap g .# runJoker
   {-# inline bifoldMap #-}
 
-instance Foldable g => Foldable (Joker g a) where
-  foldMap g = foldMap g .# runJoker
-  {-# inline foldMap #-}
+  bifoldr _c1 c2 n = foldr c2 n .# runJoker
+  {-# inline bifoldr #-}
+
+  bifoldl _c1 c2 n = foldl c2 n .# runJoker
+  {-# inline bifoldl #-}
 
 instance Traversable g => Bitraversable (Joker g) where
   bitraverse _ g = fmap Joker . traverse g .# runJoker
   {-# inline bitraverse #-}
-
-instance Traversable g => Traversable (Joker g a) where
-  traverse g = fmap Joker . traverse g .# runJoker
-  {-# inline traverse #-}

--- a/src/Data/Bifunctor/Joker.hs
+++ b/src/Data/Bifunctor/Joker.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -33,6 +34,8 @@ import Data.Bitraversable
 import Data.Coerce
 import Data.Data
 import Data.Functor.Classes
+import Data.Type.Equality (TestEquality)
+import Data.Type.Coercion (TestCoercion)
 import GHC.Generics
 
 -- | Make a 'Functor' over the second argument of a 'Bifunctor'.
@@ -45,6 +48,7 @@ newtype Joker g a b = Joker { runJoker :: g b }
            , Generic
            , Generic1
            )
+  deriving newtype (TestEquality, TestCoercion)
 
 instance Eq1 g => Eq1 (Joker g a) where
   liftEq = eqJoker #. liftEq

--- a/src/Data/Bifunctor/Product.hs
+++ b/src/Data/Bifunctor/Product.hs
@@ -41,8 +41,9 @@ instance (Contravariant (f a), Contravariant (g a)) => Contravariant (Product f 
   contramap = \f (Pair g h) -> Pair (contramap f g) (contramap f h)
   {-# inline contramap #-}
 
-instance (Eq2 f, Eq2 g, Eq a) => Eq1 (Product f g a) where
-  liftEq = liftEq2 (==)
+instance (Eq1 (f a), Eq1 (g a)) => Eq1 (Product f g a) where
+  liftEq eq (Pair x1 y1) (Pair x2 y2) =
+    liftEq eq x1 x2 && liftEq eq y1 y2
   {-# inline liftEq #-}
 
 instance (Eq2 f, Eq2 g) => Eq2 (Product f g) where
@@ -50,8 +51,9 @@ instance (Eq2 f, Eq2 g) => Eq2 (Product f g) where
     liftEq2 f g x1 x2 && liftEq2 f g y1 y2
   {-# inline liftEq2 #-}
 
-instance (Ord2 f, Ord2 g, Ord a) => Ord1 (Product f g a) where
-  liftCompare = liftCompare2 compare
+instance (Ord1 (f a), Ord1 (g a)) => Ord1 (Product f g a) where
+  liftCompare cmp (Pair x1 y1) (Pair x2 y2) =
+    liftCompare cmp x1 x2 <> liftCompare cmp y1 y2
   {-# inline liftCompare #-}
 
 instance (Ord2 f, Ord2 g) => Ord2 (Product f g) where

--- a/src/Data/Bifunctor/ShowRead.hs
+++ b/src/Data/Bifunctor/ShowRead.hs
@@ -11,9 +11,16 @@
 {-# language UndecidableInstances #-}
 {-# language Safe #-}
 
--- | Types for lifting instances of `Show`N and `Read`N
--- for record newtypes. We don't show record syntax, because
--- it's too much clutter, but we accept it when reading.
+-- | Types for lifting instances of `Show`N and `Read`N for record newtypes. We
+-- don't show record syntax, because it's too much clutter, but we accept it
+-- when reading.
+--
+-- When @a@ is a newtype (or close enough) /defined using record syntax/, and
+-- is an instance of 'Generic', 'Show', and 'Read',  @'ShowRead' a@ is a
+-- @DerivingVia@ target implementing a plain 'Show' instance and a flexible
+-- 'Read' instance. This is a fairly specific situation, but it pops up all
+-- over this package. We could pretty easily expand to non-record types if
+-- we needed to.
 module Data.Bifunctor.ShowRead
   ( ShowRead (..)
   , ShowRead1 (..)
@@ -76,6 +83,9 @@ instance (forall a b. Wraps (n a b) d c s (o a b)) => Wraps2 n d c s o
 
 data Prox (c :: Meta) (f :: Type -> Type) a = Prox
 
+-- | Given a way to read the underlying type of a newtype
+-- or similar, produce a way to read the newtype itself
+-- using either record syntax or plain syntax.
 liftReadPrecWhatever
   :: forall n d c s o.
      ( Generic n
@@ -98,9 +108,12 @@ liftReadPrecWhatever read_p =
              p <- TR.step $ read_p
              pure (to (M1 (M1 (M1 (K1 p))))))
 
+-- Copied from GHC.Read
 expectP :: TRL.Lexeme -> ReadPrec ()
 expectP lexeme = TR.lift (TRL.expect lexeme)
 
+-- | Given a way to show the type wrapped by a newtype,
+-- produce a way to show the newtype in plain syntax.
 liftShowsPrecWhatever
   :: forall n d c s o.
      ( Generic n

--- a/src/Data/Bifunctor/ShowRead.hs
+++ b/src/Data/Bifunctor/ShowRead.hs
@@ -1,0 +1,110 @@
+{-# language ConstraintKinds #-}
+{-# language DataKinds #-}
+{-# language FlexibleInstances #-}
+{-# language FunctionalDependencies #-}
+{-# language KindSignatures #-}
+{-# language MultiParamTypeClasses #-}
+{-# language QuantifiedConstraints #-}
+{-# language ScopedTypeVariables #-}
+{-# language TypeApplications #-}
+{-# language TypeFamilies #-}
+{-# language UndecidableInstances #-}
+{-# language Safe #-}
+
+-- | Types for lifting instances of `Show`N and `Read`N
+-- for record newtypes. We don't show record syntax, because
+-- it's too much clutter, but we accept it when reading.
+module Data.Bifunctor.ShowRead
+  ( ShowRead (..)
+  , ShowRead1 (..)
+  , ShowRead2 (..)
+  , liftReadPrecWhatever
+  , liftShowsPrecWhatever
+  ) where
+import qualified Text.ParserCombinators.ReadPrec as TPR
+import qualified Text.Read.Lex as TRL
+import qualified Text.Read as TR
+import Text.Read (ReadPrec, Read (..), readListPrecDefault)
+import GHC.Generics
+import Data.Kind
+import Data.Functor.Classes
+
+newtype ShowRead a = ShowRead a
+newtype ShowRead1 f a = ShowRead1 (f a)
+newtype ShowRead2 f a b = ShowRead2 (f a b)
+
+instance (Wraps n d c s o, Read o) => Read (ShowRead n) where
+  readPrec = ShowRead <$> liftReadPrecWhatever readPrec
+  readListPrec = readListPrecDefault
+
+instance (Wraps n d c s o, Show o) => Show (ShowRead n) where
+  showsPrec d (ShowRead x) = liftShowsPrecWhatever showsPrec d x
+
+instance (Wraps1 n d c s o, Read1 o) => Read1 (ShowRead1 n) where
+  liftReadPrec rp rl = ShowRead1 <$> liftReadPrecWhatever @(n _) @d @c @s @(o _) (liftReadPrec rp rl)
+
+  liftReadListPrec = liftReadListPrecDefault
+
+instance (Wraps1 n d c s o, Show1 o) => Show1 (ShowRead1 n) where
+  liftShowsPrec sp sl d (ShowRead1 x) = liftShowsPrecWhatever @(n _) @d @c @s @(o _) (liftShowsPrec sp sl) d x
+
+instance (Wraps2 n d c s o, Read2 o) => Read2 (ShowRead2 n) where
+  liftReadPrec2 rp1 rl1 rp2 rl2 = ShowRead2 <$> liftReadPrecWhatever @(n _ _) @d @c @s @(o _ _) (liftReadPrec2 rp1 rl1 rp2 rl2)
+
+  liftReadListPrec2 = liftReadListPrec2Default
+
+instance (Wraps2 n d c s o, Show2 o) => Show2 (ShowRead2 n) where
+  liftShowsPrec2 sp1 sl1 sp2 sl2 d (ShowRead2 x) =
+    liftShowsPrecWhatever @(n _ _) @d @c @s @(o _ _) (liftShowsPrec2 sp1 sl1 sp2 sl2) d x
+
+type WrapsF n d c s o =
+  ( Generic n
+  , Rep n ~ D1 d (C1 c (S1 s (Rec0 o)))
+  , Constructor c
+  , Selector s )
+
+class WrapsF n d c s o => Wraps n d c s o
+instance WrapsF n d c s o => Wraps n d c s o
+
+type family Any where
+
+class (forall a. Wraps (n a) d c s (o a), Wraps (n Any) d c s (o Any)) => Wraps1 n d c s o
+instance (forall a. Wraps (n a) d c s (o a)) => Wraps1 n d c s o
+
+class (forall a b. Wraps (n a b) d c s (o a b), Wraps (n Any Any) d c s (o Any Any)) => Wraps2 n d c s o
+instance (forall a b. Wraps (n a b) d c s (o a b)) => Wraps2 n d c s o
+
+data Prox (c :: Meta) (f :: Type -> Type) a = Prox
+
+liftReadPrecWhatever
+  :: forall n d c s o.
+     ( Generic n
+     , Wraps n d c s o
+     , Constructor c
+     , Selector s)
+  => ReadPrec o -> ReadPrec n
+liftReadPrecWhatever read_p =
+    TR.parens $ do
+      expectP (TRL.Ident $ conName (Prox @c))
+      (TPR.prec 11 $ do
+         expectP (TRL.Punc "{")
+         expectP (TRL.Ident $ selName (Prox @s))
+         expectP (TRL.Punc "=")
+         p <- read_p
+         expectP (TRL.Punc "}")
+         pure (to (M1 (M1 (M1 (K1 p))))))
+        TR.+++
+          (TPR.prec 10 $ do
+             p <- TR.step $ read_p
+             pure (to (M1 (M1 (M1 (K1 p))))))
+
+expectP :: TRL.Lexeme -> ReadPrec ()
+expectP lexeme = TR.lift (TRL.expect lexeme)
+
+liftShowsPrecWhatever
+  :: forall n d c s o.
+     ( Generic n
+     , Wraps n d c s o
+     , Constructor c )
+  => (Int -> o -> ShowS) -> Int -> n -> ShowS
+liftShowsPrecWhatever sp d n = showsUnaryWith sp (conName (Prox @c)) d (unK1 (unM1 (unM1 (unM1 (from n)))))

--- a/src/Data/Bifunctor/Sum.hs
+++ b/src/Data/Bifunctor/Sum.hs
@@ -27,8 +27,9 @@ data Sum p q a b
 
 instance (Eq1 (p a), Eq1 (q a)) => Eq1 (Sum p q a) where
   liftEq eq (L2 x) (L2 y) = liftEq eq x y
+  liftEq _ (L2 _) (R2 _) = False
+  liftEq _ (R2 _) (L2 _) = False
   liftEq eq (R2 x) (R2 y) = liftEq eq x y
-  liftEq _ _ _ = False
   {-# inline liftEq #-}
 
 instance (Eq2 f, Eq2 g) => Eq2 (Sum f g) where

--- a/src/Data/Bifunctor/Tannen.hs
+++ b/src/Data/Bifunctor/Tannen.hs
@@ -77,15 +77,14 @@ instance (Read1 f, Read2 p) => Read2 (Tannen f p) where
     liftReadPrec (liftReadPrec2 rp1 rl1 rp2 rl2) (liftReadListPrec2 rp1 rl1 rp2 rl2)
   liftReadListPrec2 = liftReadListPrec2Default
 
-instance (Show1 f, Show2 p, Show a) => Show1 (Tannen f p a) where
-  liftShowsPrec = liftShowsPrec2 showsPrec showList
+instance (Show1 f, Show1 (p a)) => Show1 (Tannen f p a) where
+  liftShowsPrec sp sl = liftShowsPrecWhatever $
+    liftShowsPrec (liftShowsPrec sp sl) (liftShowList sp sl)
 
 instance (Show1 f, Show2 p) => Show2 (Tannen f p) where
-  liftShowsPrec2 sp1 sl1 sp2 sl2 p (Tannen x) = showParen (p > 10) $
-      showString "Tannen {runTannen = "
-    . liftShowsPrec (liftShowsPrec2 sp1 sl1 sp2 sl2)
-                    (liftShowList2  sp1 sl1 sp2 sl2) 0 x
-    . showChar '}'
+  liftShowsPrec2 sp1 sl1 sp2 sl2 = liftShowsPrecWhatever $
+    liftShowsPrec (liftShowsPrec2 sp1 sl1 sp2 sl2)
+                  (liftShowList2 sp1 sl1 sp2 sl2)
 
 instance Functor f => BifunctorFunctor (Tannen f) where
   bifmap f = Tannen #. fmap f .# runTannen

--- a/src/Data/Bifunctor/Tannen.hs
+++ b/src/Data/Bifunctor/Tannen.hs
@@ -45,16 +45,16 @@ deriving stock instance (Functor f, Functor (p a)) => Functor (Tannen f p a)
 deriving stock instance (Foldable f, Foldable (p a)) => Foldable (Tannen f p a)
 deriving stock instance (Traversable f, Traversable (p a)) => Traversable (Tannen f p a)
 
-instance (Eq1 f, Eq2 p, Eq a) => Eq1 (Tannen f p a) where
-  liftEq = liftEq2 (==)
+instance (Eq1 f, Eq1 (p a)) => Eq1 (Tannen f p a) where
+  liftEq eq (Tannen x) (Tannen y) = liftEq (liftEq eq) x y
   {-# inline liftEq #-}
 
 instance (Eq1 f, Eq2 p) => Eq2 (Tannen f p) where
   liftEq2 f g (Tannen x) (Tannen y) = liftEq (liftEq2 f g) x y
   {-# inline liftEq2 #-}
 
-instance (Ord1 f, Ord2 p, Ord a) => Ord1 (Tannen f p a) where
-  liftCompare = liftCompare2 compare
+instance (Ord1 f, Ord1 (p a)) => Ord1 (Tannen f p a) where
+  liftCompare cmp (Tannen x) (Tannen y) = liftCompare (liftCompare cmp) x y
   {-# inline liftCompare #-}
 
 instance (Ord1 f, Ord2 p) => Ord2 (Tannen f p) where

--- a/src/Data/Bifunctor/Wrapped.hs
+++ b/src/Data/Bifunctor/Wrapped.hs
@@ -37,7 +37,7 @@ import Text.Read (Read (..))
 -- from a 'Bifoldable', 'Bitraversable', 'Eq2', 'Ord2', 'Show2', and 'Read2',
 -- respectively.
 newtype WrappedBifunctor p a b = WrapBifunctor { unwrapBifunctor :: p a b }
-  deriving ( Eq, Ord, Generic, Generic1, Data)
+  deriving (Eq, Ord, Generic, Generic1, Data)
   deriving (Show, Read) via ShowRead (WrappedBifunctor p a b)
 
 instance (Eq2 p, Eq a) => Eq1 (WrappedBifunctor p a) where

--- a/src/Data/Bifunctor/Wrapped.hs
+++ b/src/Data/Bifunctor/Wrapped.hs
@@ -30,8 +30,12 @@ import Data.Coerce
 import Data.Data
 import Data.Functor.Classes
 import GHC.Generics
+import Text.Read (Read (..))
 
--- | Make a 'Functor' over the second argument of a 'Bifunctor'.
+-- | Make a 'Functor' over the second argument of a 'Bifunctor'. This also
+-- makes a 'Foldable', 'Traversable', 'Eq1', 'Ord1', 'Show1', and 'Read1'
+-- from a 'Bifoldable', 'Bitraversable', 'Eq2', 'Ord2', 'Show2', and 'Read2',
+-- respectively.
 newtype WrappedBifunctor p a b = WrapBifunctor { unwrapBifunctor :: p a b }
   deriving ( Eq, Ord, Generic, Generic1, Data)
   deriving (Show, Read) via ShowRead (WrappedBifunctor p a b)
@@ -66,10 +70,14 @@ instance Ord2 p => Ord2 (WrappedBifunctor p) where
   liftCompare2 = coerce (liftCompare2 :: (a -> b -> Ordering) -> (c -> d -> Ordering) -> p a c -> p b d -> Ordering)
   {-# inline liftCompare2 #-}
 
-deriving via ShowRead1 (WrappedBifunctor p a) instance Show1 (p a) => Show1 (WrappedBifunctor p a)
+instance (Show2 p, Show a) => Show1 (WrappedBifunctor p a) where
+  liftShowsPrec sp sl = liftShowsPrecWhatever $ liftShowsPrec2 showsPrec showList sp sl
+
 deriving via ShowRead2 (WrappedBifunctor p) instance Show2 p => Show2 (WrappedBifunctor p)
 
-deriving via ShowRead1 (WrappedBifunctor p a) instance Read1 (p a) => Read1 (WrappedBifunctor p a)
+instance (Read2 p, Read a) => Read1 (WrappedBifunctor p a) where
+  liftReadPrec rp rl = liftReadPrecWhatever $ liftReadPrec2 readPrec readListPrec rp rl
+
 deriving via ShowRead2 (WrappedBifunctor p) instance Read2 p => Read2 (WrappedBifunctor p)
 
 instance BifunctorFunctor WrappedBifunctor where

--- a/src/Data/Bifunctor/Yoneda.hs
+++ b/src/Data/Bifunctor/Yoneda.hs
@@ -176,6 +176,13 @@ instance Bitraversable p => Bitraversable (Coyoneda p) where
   bitraverse = \f g (Coyoneda h i p) -> liftCoyoneda <$> bitraverse (f . h) (g . i) p
   {-# inline bitraverse #-}
 
+instance (Foldable (p a), Bifunctor p) => Foldable (Coyoneda p a) where
+  foldMap f (Coyoneda xa yb pxy) = fold (bimap xa (f . yb) pxy)
+
+instance (Traversable (p a), Bifunctor p) => Traversable (Coyoneda p a) where
+  traverse f (Coyoneda xa yb pxy) =
+    fmap liftCoyoneda $ sequenceA (bimap xa (f . yb) pxy)
+
 instance Biapplicative p => Biapplicative (Coyoneda p) where
   bipure a b = bireturn (bipure a b)
   {-# inline bipure #-}


### PR DESCRIPTION
* Make all the `Read`, `Show`, `Read1`, `Show1`, `Read2`, and `Show2`
  instances act like `Backwards` and `Reverse`.
* Add reading and showing instances for `Yoneda` and `Coyoneda`.
* Change some instances to simplify constraints. For example, change
  `(Eq1 f, Eq a)` to `Eq (f a)` when possible.