### PR TITLE
Backport GHC!7687

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,11 @@
+next [????.??.??]
+-----------------
+* Backport an upstream GHC change which removes the default implementation of
+  `bitraverse`. Per the discussion in
+  https://github.com/haskell/core-libraries-committee/issues/47, this default
+  implementation was completely broken, as attempting to use it would always
+  result in an infinite loop.
+
 5.5.11 [2021.04.30]
 -------------------
 * Allow building with `template-haskell-2.18` (GHC 9.2).

--- a/old-src/ghc801/Data/Bitraversable.hs
+++ b/old-src/ghc801/Data/Bitraversable.hs
@@ -141,8 +141,6 @@ class (Bifunctor t, Bifoldable t) => Bitraversable t where
   --
   -- For a version that ignores the results, see 'bitraverse_'.
   bitraverse :: Applicative f => (a -> f c) -> (b -> f d) -> t a b -> f (t c d)
-  bitraverse f g = bisequenceA . bimap f g
-  {-# INLINE bitraverse #-}
 
 
 -- | Sequences all the actions in a structure, building a new structure with the


### PR DESCRIPTION
This backports an upstream change to `base` which removes the broken default implementation of `bitraverse`. See https://gitlab.haskell.org/ghc/ghc/-/merge_requests/7687 for the upstream change.

Fixes #102.