### PR TITLE
Make `Biapplicative` instances for tuples lazy (backport of #96 to `5` branch)

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,8 @@
+next [????.??.??]
+-----------------
+* Make the `Biapplicative` instances for tuples lazy, to match their `Bifunctor`
+  instances.
+
 5.5.12 [2022.05.07]
 -------------------
 * Backport an upstream GHC change which removes the default implementation of

--- a/src/Data/Biapplicative.hs
+++ b/src/Data/Biapplicative.hs
@@ -268,9 +268,9 @@ traverseBiaPair f (x,y) = bimap ((,) x) ((,) x) (f y)
 instance Biapplicative (,) where
   bipure = (,)
   {-# INLINE bipure #-}
-  (f, g) <<*>> (a, b) = (f a, g b)
+  ~(f, g) <<*>> ~(a, b) = (f a, g b)
   {-# INLINE (<<*>>) #-}
-  biliftA2 f g (x, y) (a, b) = (f x a, g y b)
+  biliftA2 f g ~(x, y) ~(a, b) = (f x a, g y b)
   {-# INLINE biliftA2 #-}
 
 instance Biapplicative Arg where
@@ -284,31 +284,31 @@ instance Biapplicative Arg where
 instance Monoid x => Biapplicative ((,,) x) where
   bipure = (,,) mempty
   {-# INLINE bipure #-}
-  (x, f, g) <<*>> (x', a, b) = (mappend x x', f a, g b)
+  ~(x, f, g) <<*>> ~(x', a, b) = (mappend x x', f a, g b)
   {-# INLINE (<<*>>) #-}
 
 instance (Monoid x, Monoid y) => Biapplicative ((,,,) x y) where
   bipure = (,,,) mempty mempty
   {-# INLINE bipure #-}
-  (x, y, f, g) <<*>> (x', y', a, b) = (mappend x x', mappend y y', f a, g b)
+  ~(x, y, f, g) <<*>> ~(x', y', a, b) = (mappend x x', mappend y y', f a, g b)
   {-# INLINE (<<*>>) #-}
 
 instance (Monoid x, Monoid y, Monoid z) => Biapplicative ((,,,,) x y z) where
   bipure = (,,,,) mempty mempty mempty
   {-# INLINE bipure #-}
-  (x, y, z, f, g) <<*>> (x', y', z', a, b) = (mappend x x', mappend y y', mappend z z', f a, g b)
+  ~(x, y, z, f, g) <<*>> ~(x', y', z', a, b) = (mappend x x', mappend y y', mappend z z', f a, g b)
   {-# INLINE (<<*>>) #-}
 
 instance (Monoid x, Monoid y, Monoid z, Monoid w) => Biapplicative ((,,,,,) x y z w) where
   bipure = (,,,,,) mempty mempty mempty mempty
   {-# INLINE bipure #-}
-  (x, y, z, w, f, g) <<*>> (x', y', z', w', a, b) = (mappend x x', mappend y y', mappend z z', mappend w w', f a, g b)
+  ~(x, y, z, w, f, g) <<*>> ~(x', y', z', w', a, b) = (mappend x x', mappend y y', mappend z z', mappend w w', f a, g b)
   {-# INLINE (<<*>>) #-}
 
 instance (Monoid x, Monoid y, Monoid z, Monoid w, Monoid v) => Biapplicative ((,,,,,,) x y z w v) where
   bipure = (,,,,,,) mempty mempty mempty mempty mempty
   {-# INLINE bipure #-}
-  (x, y, z, w, v, f, g) <<*>> (x', y', z', w', v', a, b) = (mappend x x', mappend y y', mappend z z', mappend w w', mappend v v', f a, g b)
+  ~(x, y, z, w, v, f, g) <<*>> ~(x', y', z', w', v', a, b) = (mappend x x', mappend y y', mappend z z', mappend w w', mappend v v', f a, g b)
   {-# INLINE (<<*>>) #-}
 
 #ifdef MIN_VERSION_tagged


### PR DESCRIPTION
(This is a backport of the changes from #96 to the `5` branch, as requested in #104.)

Previously, `<<*>>` and `biliftA2` were strict in their tuple arguments. Unfortunately, the `Bifunctor` instances (defined in `base`), are *lazy* in their tuple arguments. This inconsistency made tuples utterly useless for `Biapplicative` traversals. Make `<<*>>` and `biliftA2` lazy for tuples.

(cherry picked from commit 309658e83af646b8b33a8f81c9d9e538a843e3b1)