### PR TITLE
Adapt to quantified superclass changes on GHC HEAD

### DIFF
--- a/src/Data/Bifunctor/ShowRead.hs
+++ b/src/Data/Bifunctor/ShowRead.hs
@@ -50,20 +50,39 @@ instance (Wraps n d c s o, Show o) => Show (ShowRead n) where
 
 instance (Wraps1 n d c s o, Read1 o) => Read1 (ShowRead1 n) where
   liftReadPrec rp rl = ShowRead1 <$> liftReadPrecWhatever @(n _) @d @c @s @(o _) (liftReadPrec rp rl)
-
   liftReadListPrec = liftReadListPrecDefault
+
+instance (Wraps1 n f c s o, Read1 o, Read a) => Read (ShowRead1 n a) where
+  readPrec = readPrec1
+  readListPrec = readListPrecDefault
 
 instance (Wraps1 n d c s o, Show1 o) => Show1 (ShowRead1 n) where
   liftShowsPrec sp sl d (ShowRead1 x) = liftShowsPrecWhatever @(n _) @d @c @s @(o _) (liftShowsPrec sp sl) d x
 
+instance (Wraps1 n d c s o, Show1 o, Show a) => Show (ShowRead1 n a) where
+  showsPrec = showsPrec1
+
 instance (Wraps2 n d c s o, Read2 o) => Read2 (ShowRead2 n) where
   liftReadPrec2 rp1 rl1 rp2 rl2 = ShowRead2 <$> liftReadPrecWhatever @(n _ _) @d @c @s @(o _ _) (liftReadPrec2 rp1 rl1 rp2 rl2)
-
   liftReadListPrec2 = liftReadListPrec2Default
+
+instance (Wraps2 n f c s o, Read2 o, Read a, Read b) => Read (ShowRead2 n a b) where
+  readPrec = readPrec2
+  readListPrec = readListPrecDefault
+
+instance (Wraps2 n f c s o, Read2 o, Read a) => Read1 (ShowRead2 n a) where
+  liftReadPrec = liftReadPrec2 readPrec readListPrec
+  liftReadListPrec = liftReadListPrecDefault
 
 instance (Wraps2 n d c s o, Show2 o) => Show2 (ShowRead2 n) where
   liftShowsPrec2 sp1 sl1 sp2 sl2 d (ShowRead2 x) =
     liftShowsPrecWhatever @(n _ _) @d @c @s @(o _ _) (liftShowsPrec2 sp1 sl1 sp2 sl2) d x
+
+instance (Wraps2 n d c s o, Show2 o, Show a, Show b) => Show (ShowRead2 n a b) where
+  showsPrec = showsPrec2
+
+instance (Wraps2 n d c s o, Show2 o, Show a) => Show1 (ShowRead2 n a) where
+  liftShowsPrec = liftShowsPrec2 showsPrec showList
 
 type WrapsF n d c s o =
   ( Generic n

--- a/tests/BifunctorSpec.hs
+++ b/tests/BifunctorSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -6,7 +7,9 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -68,6 +71,7 @@ data Strange a b c
     | T3 [[a]] [[b]] [[c]]   -- nested lists
     | T4 (c,(b,b),(c,c))     -- tuples
     | T5 ([c],Strange a b c) -- tycons
+  deriving (Functor, Foldable, Traversable)
 
 type IntFun a b = (b -> Int) -> a
 data StrangeFunctions a b c
@@ -75,6 +79,7 @@ data StrangeFunctions a b c
     | T7 (a -> (c,a))        -- functions and tuples
     | T8 ((b -> a) -> c)     -- continuation
     | T9 (IntFun b c)        -- type synonyms
+  deriving Functor
 
 data StrangeGADT a b where
     T10 :: Ord d            => d        -> StrangeGADT c d
@@ -83,37 +88,73 @@ data StrangeGADT a b where
     T13 :: i ~ Int          => Int      -> StrangeGADT h i
     T14 :: k ~ Int          => k        -> StrangeGADT j k
     T15 :: (n ~ c, c ~ Int) => Int -> c -> StrangeGADT m n
+deriving instance Foldable (StrangeGADT a)
 
 data NotPrimitivelyRecursive a b
     = S1 (NotPrimitivelyRecursive (a,a) (b, a))
     | S2 a
     | S3 b
+  deriving (Functor, Foldable, Traversable)
 
 newtype OneTwoCompose f g a b = OneTwoCompose (f (g a b))
-  deriving (Arbitrary, Eq, Show)
+  deriving (Arbitrary, Eq, Foldable, Functor, Show, Traversable)
 
 newtype ComplexConstraint f g a b = ComplexConstraint (f Int Int (g a,a,b))
+instance (Bifunctor (f Int), Functor g) =>
+    Functor (ComplexConstraint f g a) where
+  fmap f (ComplexConstraint x) =
+    ComplexConstraint (bimap id (\(ga,a,b) -> (ga,a,f b)) x)
+instance (Bifoldable (f Int), Foldable g) =>
+    Foldable (ComplexConstraint f g a) where
+  foldMap f (ComplexConstraint x) =
+    bifoldMap (const mempty) (\(_,_,b) -> f b) x
+instance (Bitraversable (f Int), Traversable g) =>
+    Traversable (ComplexConstraint f g a) where
+  traverse f (ComplexConstraint x) =
+    ComplexConstraint <$> bitraverse pure (\(ga,a,b) -> (ga,a,) <$> f b) x
 
 data Universal a b
     = Universal  (forall b. (b,[a]))
     | Universal2 (forall f. Bifunctor f => f a b)
     | Universal3 (forall a. Maybe a) -- reuse a
     | NotReallyUniversal (forall b. a)
+instance Functor (Universal a) where
+  fmap f (Universal  x)         = Universal x
+  fmap f (Universal2 x)         = Universal2 (bimap id f x)
+  fmap f (Universal3 x)         = Universal3 x
+  fmap f (NotReallyUniversal x) = NotReallyUniversal x
 
 data Existential a b
     = forall a. ExistentialList [a]
     | forall f. Bitraversable f => ExistentialFunctor (f a b)
     | forall b. SneakyUseSameName (Maybe b)
+instance Functor (Existential a) where
+  fmap f (ExistentialList x)    = ExistentialList x
+  fmap f (ExistentialFunctor x) = ExistentialFunctor (bimap id f x)
+  fmap f (SneakyUseSameName x)  = SneakyUseSameName x
+instance Foldable (Existential a) where
+  foldMap f (ExistentialList _)    = mempty
+  foldMap f (ExistentialFunctor x) = bifoldMap (const mempty) f x
+  foldMap f (SneakyUseSameName _)  = mempty
+instance Traversable (Existential a) where
+  traverse f (ExistentialList x)    = pure $ ExistentialList x
+  traverse f (ExistentialFunctor x) = ExistentialFunctor <$> bitraverse pure f x
+  traverse f (SneakyUseSameName x)  = pure $ SneakyUseSameName x
 
 data IntHash a b
     = IntHash Int# Int#
     | IntHashTuple Int# a b (a, b, Int, IntHash Int (a, b, Int))
+  deriving (Functor, Foldable, Traversable)
 
 data IntHashFun a b
     = IntHashFun ((((a -> Int#) -> b) -> Int#) -> a)
+  deriving Functor
 
 data Empty1 a b
+  deriving (Functor, Foldable, Traversable)
+
 data Empty2 a b
+  deriving (Functor, Foldable, Traversable)
 #if __GLASGOW_HASKELL__ >= 708
 type role Empty2 nominal nominal
 #endif
@@ -121,11 +162,15 @@ type role Empty2 nominal nominal
 data TyCon81 a b
     = TyCon81a (forall c. c -> (forall d. a -> d) -> a)
     | TyCon81b (Int -> forall c. c -> b)
+instance Functor (TyCon81 a) where
+  fmap f (TyCon81a g) = TyCon81a g
+  fmap f (TyCon81b g) = TyCon81b (\x y -> f (g x y))
 
 type family F :: * -> * -> *
 type instance F = Either
 
 data TyCon82 a b = TyCon82 (F a b)
+  deriving (Functor, Foldable, Traversable)
 
 -- Data families
 
@@ -136,6 +181,7 @@ data instance StrangeFam a  b c
     | T3Fam [[a]] [[b]] [[c]]   -- nested lists
     | T4Fam (c,(b,b),(c,c))     -- tuples
     | T5Fam ([c],Strange a b c) -- tycons
+  deriving (Functor, Foldable, Traversable)
 
 data family   StrangeFunctionsFam x y z
 data instance StrangeFunctionsFam a b c
@@ -143,6 +189,7 @@ data instance StrangeFunctionsFam a b c
     | T7Fam (a -> (c,a))        -- functions and tuples
     | T8Fam ((b -> a) -> c)     -- continuation
     | T9Fam (IntFun b c)        -- type synonyms
+  deriving Functor
 
 data family   StrangeGADTFam x y
 data instance StrangeGADTFam a b where
@@ -152,19 +199,33 @@ data instance StrangeGADTFam a b where
     T13Fam :: i ~ Int          => Int      -> StrangeGADTFam h i
     T14Fam :: k ~ Int          => k        -> StrangeGADTFam j k
     T15Fam :: (n ~ c, c ~ Int) => Int -> c -> StrangeGADTFam m n
+deriving instance Foldable (StrangeGADTFam a)
 
 data family   NotPrimitivelyRecursiveFam x y
 data instance NotPrimitivelyRecursiveFam a b
     = S1Fam (NotPrimitivelyRecursive (a,a) (b, a))
     | S2Fam a
     | S3Fam b
+  deriving (Functor, Foldable, Traversable)
 
 data family      OneTwoComposeFam (j :: * -> *) (k :: * -> * -> *) x y
 newtype instance OneTwoComposeFam f g a b = OneTwoComposeFam (f (g a b))
-  deriving (Arbitrary, Eq, Show)
+  deriving (Arbitrary, Eq, Foldable, Functor, Show, Traversable)
 
 data family      ComplexConstraintFam (j :: * -> * -> * -> *) (k :: * -> *) x y
 newtype instance ComplexConstraintFam f g a b = ComplexConstraintFam (f Int Int (g a,a,b))
+instance (Bifunctor (f Int), Functor g) =>
+    Functor (ComplexConstraintFam f g a) where
+  fmap f (ComplexConstraintFam x) =
+    ComplexConstraintFam (bimap id (\(ga,a,b) -> (ga,a,f b)) x)
+instance (Bifoldable (f Int), Foldable g) =>
+    Foldable (ComplexConstraintFam f g a) where
+  foldMap f (ComplexConstraintFam x) =
+    bifoldMap (const mempty) (\(_,_,b) -> f b) x
+instance (Bitraversable (f Int), Traversable g) =>
+    Traversable (ComplexConstraintFam f g a) where
+  traverse f (ComplexConstraintFam x) =
+    ComplexConstraintFam <$> bitraverse pure (\(ga,a,b) -> (ga,a,) <$> f b) x
 
 data family   UniversalFam x y
 data instance UniversalFam a b
@@ -172,29 +233,52 @@ data instance UniversalFam a b
     | Universal2Fam (forall f. Bifunctor f => f a b)
     | Universal3Fam (forall a. Maybe a) -- reuse a
     | NotReallyUniversalFam (forall b. a)
+instance Functor (UniversalFam a) where
+  fmap f (UniversalFam  x)         = UniversalFam x
+  fmap f (Universal2Fam x)         = Universal2Fam (bimap id f x)
+  fmap f (Universal3Fam x)         = Universal3Fam x
+  fmap f (NotReallyUniversalFam x) = NotReallyUniversalFam x
 
 data family   ExistentialFam x y
 data instance ExistentialFam a b
     = forall a. ExistentialListFam [a]
     | forall f. Bitraversable f => ExistentialFunctorFam (f a b)
     | forall b. SneakyUseSameNameFam (Maybe b)
+instance Functor (ExistentialFam a) where
+  fmap f (ExistentialListFam x)    = ExistentialListFam x
+  fmap f (ExistentialFunctorFam x) = ExistentialFunctorFam (bimap id f x)
+  fmap f (SneakyUseSameNameFam x)  = SneakyUseSameNameFam x
+instance Foldable (ExistentialFam a) where
+  foldMap f (ExistentialListFam _)    = mempty
+  foldMap f (ExistentialFunctorFam x) = bifoldMap (const mempty) f x
+  foldMap f (SneakyUseSameNameFam _)  = mempty
+instance Traversable (ExistentialFam a) where
+  traverse f (ExistentialListFam x)    = pure $ ExistentialListFam x
+  traverse f (ExistentialFunctorFam x) = ExistentialFunctorFam <$> bitraverse pure f x
+  traverse f (SneakyUseSameNameFam x)  = pure $ SneakyUseSameNameFam x
 
 data family   IntHashFam x y
 data instance IntHashFam a b
     = IntHashFam Int# Int#
     | IntHashTupleFam Int# a b (a, b, Int, IntHashFam Int (a, b, Int))
+  deriving (Functor, Foldable, Traversable)
 
 data family   IntHashFunFam x y
 data instance IntHashFunFam a b
     = IntHashFunFam ((((a -> Int#) -> b) -> Int#) -> a)
+  deriving Functor
 
 data family   TyFamily81 x y
 data instance TyFamily81 a b
     = TyFamily81a (forall c. c -> (forall d. a -> d) -> a)
     | TyFamily81b (Int -> forall c. c -> b)
+instance Functor (TyFamily81 a) where
+  fmap f (TyFamily81a g) = TyFamily81a g
+  fmap f (TyFamily81b g) = TyFamily81b (\x y -> f (g x y))
 
 data family   TyFamily82 x y
 data instance TyFamily82 a b = TyFamily82 (F a b)
+  deriving (Functor, Foldable, Traversable)
 
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR contains two patches needed to make the `main` branch typecheck on GHC HEAD, which adds quantified superclasses to various type classes in `base`:

## Define missing {Read,Show}{,1} instances in Data.Bifunctor.ShowRead

GHC 9.6 adds quantified superclasses to `{Read,Show}{1,2}`, which requires defining corresponding instances in `Data.Bifunctor.ShowRead` in order for the existing `{Read,Show}{1,2}` instances to typecheck.

## Define missing Functor/Foldable/Traversable instances in the test suite

A future version of GHC will add a quantified superclass to `Bifunctor`, which causes the `bifunctors` test suite to no longer typecheck due to missing `Functor` instances. This patch adds them, along with `Foldable` and `Traversable` instances to prepare for a future in which `Bifoldable` and `Bitraversable` have quantified superclasses as well.