### PR TITLE
Bump major version, warn about `bifunctor-classes-compat` migration in CHANGELOG

### DIFF
--- a/bifunctors.cabal
+++ b/bifunctors.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.24
 name:          bifunctors
 category:      Data, Functors
-version:       5.5.14
+version:       5.6
 license:       BSD3
 license-file:  LICENSE
 author:        Edward A. Kmett


### PR DESCRIPTION
Addresses #114.