### PR TITLE
Migrate `Foldable1`/`Bifoldable1` instances from `semigroupoids`

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.14.3
+# version: 0.15.20230217
 #
-# REGENDATA ("0.14.3",["github","cabal.project"])
+# REGENDATA ("0.15.20230217",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes:
       60
     container:
@@ -28,9 +28,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.2.2
+          - compiler: ghc-9.6.0.20230210
             compilerKind: ghc
-            compilerVersion: 9.2.2
+            compilerVersion: 9.6.0.20230210
+            setup-method: ghcup
+            allow-failure: true
+          - compiler: ghc-9.4.4
+            compilerKind: ghc
+            compilerVersion: 9.4.4
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.2.6
+            compilerKind: ghc
+            compilerVersion: 9.2.6
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -61,18 +71,20 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
+            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
             apt-add-repository -y 'ppa:hvr/ghc'
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -90,20 +102,20 @@ jobs:
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
             echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
             echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           fi
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 90600)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -132,6 +144,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -155,7 +179,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -187,6 +211,9 @@ jobs:
             location: https://github.com/ekmett/comonad.git
             branch:   main
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(bifunctors)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
@@ -194,8 +221,8 @@ jobs:
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
-      - name: cache
-        uses: actions/cache@v2
+      - name: restore cache
+        uses: actions/cache/restore@v3
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -216,4 +243,10 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+      - name: save cache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
+          path: ~/.cabal/store

--- a/bifunctors.cabal
+++ b/bifunctors.cabal
@@ -17,7 +17,9 @@ tested-with:   GHC == 8.6.5
              , GHC == 8.8.4
              , GHC == 8.10.7
              , GHC == 9.0.2
-             , GHC == 9.2.2
+             , GHC == 9.2.6
+             , GHC == 9.4.4
+             , GHC == 9.6.1
 extra-source-files:
   CHANGELOG.markdown
   README.markdown
@@ -37,6 +39,9 @@ library
     , template-haskell
     , th-abstraction   ^>= 0.4.2.0
     , transformers     >= 0.5 && < 0.7
+
+  if !impl(ghc >= 9.6)
+    build-depends: foldable1-classes-compat >= 0.1 && < 0.2
 
   exposed-modules:
     Data.Biapplicative

--- a/src/Data/Bifunctor/Clown.hs
+++ b/src/Data/Bifunctor/Clown.hs
@@ -23,10 +23,12 @@ module Data.Bifunctor.Clown
 import Data.Coerce
 import Data.Biapplicative
 import Data.Bifoldable
+import Data.Bifoldable1 (Bifoldable1(..))
 import Data.Bifunctor
 import Data.Bifunctor.ShowRead
 import Data.Bifunctor.Unsafe
 import Data.Bitraversable
+import Data.Foldable1 (Foldable1(..))
 import Data.Functor.Contravariant
 import Data.Data
 import Data.Functor.Classes
@@ -116,6 +118,10 @@ instance Foldable f => Bifoldable (Clown f) where
   {-# INLINE bifoldr #-}
   bifoldl c1 _c2 n = foldl c1 n .# runClown
   {-# INLINE bifoldl #-}
+
+instance Foldable1 f => Bifoldable1 (Clown f) where
+  bifoldMap1 f _ = foldMap1 f . runClown
+  {-# INLINE bifoldMap1 #-}
 
 instance Foldable (Clown f a) where
   foldMap _ = mempty

--- a/src/Data/Bifunctor/Flip.hs
+++ b/src/Data/Bifunctor/Flip.hs
@@ -19,6 +19,7 @@ module Data.Bifunctor.Flip
 import qualified Control.Category as Cat
 import Data.Biapplicative
 import Data.Bifoldable
+import Data.Bifoldable1 (Bifoldable1(..))
 import Data.Bifunctor
 import Data.Bifunctor.ShowRead
 import Data.Bifunctor.Functor
@@ -85,6 +86,10 @@ instance Biapplicative p => Biapplicative (Flip p) where
 instance Bifoldable p => Bifoldable (Flip p) where
   bifoldMap f g = bifoldMap g f . runFlip
   {-# INLINE bifoldMap #-}
+
+instance Bifoldable1 p => Bifoldable1 (Flip p) where
+  bifoldMap1 f g = bifoldMap1 g f . runFlip
+  {-# INLINE bifoldMap1 #-}
 
 instance Bifoldable p => Foldable (Flip p a) where
   foldMap f = bifoldMap f (const mempty) . runFlip

--- a/src/Data/Bifunctor/Join.hs
+++ b/src/Data/Bifunctor/Join.hs
@@ -27,12 +27,14 @@ import Control.Applicative (Applicative (liftA2))
 #endif
 import Data.Biapplicative
 import Data.Bifoldable
+import Data.Bifoldable1 (Bifoldable1(..))
 import Data.Bifunctor
 import Data.Bifunctor.ShowRead
 import Data.Bifunctor.Unsafe
 import Data.Bitraversable
 import Data.Coerce
 import Data.Data
+import Data.Foldable1 (Foldable1(..))
 import Data.Functor.Classes
 import GHC.Generics
 import Language.Haskell.TH.Syntax (Lift)
@@ -97,6 +99,10 @@ instance Biapplicative p => Applicative (Join p) where
 instance Bifoldable p => Foldable (Join p) where
   foldMap f = bifoldMap f f .# runJoin
   {-# inline foldMap #-}
+
+instance Bifoldable1 p => Foldable1 (Join p) where
+  foldMap1 f (Join a) = bifoldMap1 f f a
+  {-# INLINE foldMap1 #-}
 
 instance Bitraversable p => Traversable (Join p) where
   traverse f = fmap Join . bitraverse f f .# runJoin

--- a/src/Data/Bifunctor/Joker.hs
+++ b/src/Data/Bifunctor/Joker.hs
@@ -34,9 +34,11 @@ import Data.Bifunctor.ShowRead
 import Data.Bifunctor.Unsafe
 import Data.Biapplicative
 import Data.Bifoldable
+import Data.Bifoldable1 (Bifoldable1(..))
 import Data.Bitraversable
 import Data.Coerce
 import Data.Data
+import Data.Foldable1 (Foldable1(..))
 import Data.Functor.Classes
 import Data.Type.Equality (TestEquality)
 import Data.Type.Coercion (TestCoercion)
@@ -54,7 +56,7 @@ newtype Joker g a b = Joker { runJoker :: g b }
            , Generic1
            , Lift
            )
-  deriving newtype (Eq, Ord, Foldable, TestEquality, TestCoercion)
+  deriving newtype (Eq, Ord, Foldable, Foldable1, TestEquality, TestCoercion)
 
 instance Eq1 g => Eq1 (Joker g a) where
   liftEq = eqJoker #. liftEq
@@ -131,6 +133,10 @@ instance Foldable g => Bifoldable (Joker g) where
 
   bifoldl _c1 c2 n = foldl c2 n .# runJoker
   {-# inline bifoldl #-}
+
+instance Foldable1 g => Bifoldable1 (Joker g) where
+  bifoldMap1 _ g = foldMap1 g . runJoker
+  {-# INLINE bifoldMap1 #-}
 
 instance Traversable g => Bitraversable (Joker g) where
   bitraverse _ g = fmap Joker . traverse g .# runJoker

--- a/src/Data/Bifunctor/Product.hs
+++ b/src/Data/Bifunctor/Product.hs
@@ -24,6 +24,7 @@ import qualified Control.Arrow as A
 import Control.Category
 import Data.Biapplicative
 import Data.Bifoldable
+import Data.Bifoldable1 (Bifoldable1(..))
 import Data.Bifunctor
 import Data.Bifunctor.Classes
 import Data.Bifunctor.Functor
@@ -103,6 +104,10 @@ instance (Biapplicative f, Biapplicative g) => Biapplicative (Product f g) where
 instance (Bifoldable f, Bifoldable g) => Bifoldable (Product f g) where
   bifoldMap = \f g (Pair x y) -> bifoldMap f g x `mappend` bifoldMap f g y
   {-# inline bifoldMap #-}
+
+instance (Bifoldable1 f, Bifoldable1 g) => Bifoldable1 (Product f g) where
+  bifoldMap1 f g (Pair x y) = bifoldMap1 f g x <> bifoldMap1 f g y
+  {-# INLINE bifoldMap1 #-}
 
 instance (Bitraversable f, Bitraversable g) => Bitraversable (Product f g) where
   bitraverse = \f g (Pair x y) -> Pair <$> bitraverse f g x <*> bitraverse f g y

--- a/src/Data/Bifunctor/Tannen.hs
+++ b/src/Data/Bifunctor/Tannen.hs
@@ -30,8 +30,10 @@ import Data.Bifunctor.ShowRead
 import Data.Bifunctor.Unsafe
 import Data.Biapplicative
 import Data.Bifoldable
+import Data.Bifoldable1 (Bifoldable1(..))
 import Data.Bitraversable
 import Data.Data
+import Data.Foldable1 (Foldable1(..))
 import Data.Functor.Classes
 import GHC.Generics
 import Language.Haskell.TH.Syntax (Lift)
@@ -125,6 +127,10 @@ instance (Applicative f, Biapplicative p) => Biapplicative (Tannen f p) where
 instance (Foldable f, Bifoldable p) => Bifoldable (Tannen f p) where
   bifoldMap f g = foldMap (bifoldMap f g) .# runTannen
   {-# inline bifoldMap #-}
+
+instance (Foldable1 f, Bifoldable1 p) => Bifoldable1 (Tannen f p) where
+  bifoldMap1 f g = foldMap1 (bifoldMap1 f g) . runTannen
+  {-# INLINE bifoldMap1 #-}
 
 instance (Traversable f, Bitraversable p) => Bitraversable (Tannen f p) where
   bitraverse f g = fmap Tannen . traverse (bitraverse f g) .# runTannen

--- a/src/Data/Bifunctor/Wrapped.hs
+++ b/src/Data/Bifunctor/Wrapped.hs
@@ -21,6 +21,7 @@ module Data.Bifunctor.Wrapped
 
 import Data.Biapplicative
 import Data.Bifoldable
+import Data.Bifoldable1 (Bifoldable1(..))
 import Data.Bifunctor
 import Data.Bifunctor.Functor
 import Data.Bifunctor.ShowRead
@@ -45,8 +46,8 @@ instance (Eq2 p, Eq a) => Eq1 (WrappedBifunctor p a) where
   {-# inline liftEq #-}
 
 instance Eq2 p => Eq2 (WrappedBifunctor p) where
-  liftEq2 
-    :: forall a b c d. 
+  liftEq2
+    :: forall a b c d.
        (a -> b -> Bool)
     -> (c -> d -> Bool)
     -> WrappedBifunctor p a c
@@ -60,8 +61,8 @@ instance (Ord2 p, Ord a) => Ord1 (WrappedBifunctor p a) where
   {-# inline liftCompare #-}
 
 instance Ord2 p => Ord2 (WrappedBifunctor p) where
-  liftCompare2 
-    :: forall a b c d. 
+  liftCompare2
+    :: forall a b c d.
        (a -> b -> Ordering)
     -> (c -> d -> Ordering)
     -> WrappedBifunctor p a c
@@ -121,6 +122,10 @@ instance Bifoldable p => Foldable (WrappedBifunctor p a) where
 instance Bifoldable p => Bifoldable (WrappedBifunctor p) where
   bifoldMap f g = bifoldMap f g . unwrapBifunctor
   {-# inline bifoldMap #-}
+
+instance Bifoldable1 p => Bifoldable1 (WrappedBifunctor p) where
+  bifoldMap1 f g = bifoldMap1 f g . unwrapBifunctor
+  {-# INLINE bifoldMap1 #-}
 
 instance Bitraversable p => Traversable (WrappedBifunctor p a) where
   traverse f = fmap WrapBifunctor . bitraverse pure f . unwrapBifunctor


### PR DESCRIPTION
(This cherry-picks #115 to the `main` branch.)

This is part of an effort to adapt to [this Core Libraries Proposal](haskell/core-libraries-committee#9), which adds `Foldable1` and `Bifoldable1` to `base`. This is a prerequisite for re-exporting these classes from `semigroupoids`; see ekmett/semigroupoids#130.