### PR TITLE
Forward-port some changes from the `5` branch to `main`

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20230217
+# version: 0.15.20230312
 #
-# REGENDATA ("0.15.20230217",["github","cabal.project"])
+# REGENDATA ("0.15.20230312",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -28,11 +28,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.6.0.20230210
+          - compiler: ghc-9.6.1
             compilerKind: ghc
-            compilerVersion: 9.6.0.20230210
+            compilerVersion: 9.6.1
             setup-method: ghcup
-            allow-failure: true
+            allow-failure: false
           - compiler: ghc-9.4.4
             compilerKind: ghc
             compilerVersion: 9.4.4
@@ -73,9 +73,8 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
             apt-add-repository -y 'ppa:hvr/ghc'
             apt-get update
@@ -83,8 +82,7 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -102,20 +100,20 @@ jobs:
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
             echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
             echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           fi
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 90600)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -144,18 +142,6 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
-          if $HEADHACKAGE; then
-          cat >> $CABAL_CONFIG <<EOF
-          repository head.hackage.ghc.haskell.org
-             url: https://ghc.gitlab.haskell.org/head.hackage/
-             secure: True
-             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
-             key-threshold: 3
-          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
-          EOF
-          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -211,9 +197,6 @@ jobs:
             location: https://github.com/ekmett/comonad.git
             branch:   main
           EOF
-          if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
-          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(bifunctors)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -38,7 +38,11 @@
 
 5.6.1 [2023.mm.dd]
 ------------------
-* Provide instances for the `Swap` and `Assoc` type classes from the `assoc` package.
+* Provide instances for the `Swap` and `Assoc` type classes from the `assoc`
+  package. (These instances were previously defined in `assoc` itself, but they
+  have been migrated over to `bifunctors` in tandem with the `assoc-1.1`
+  release.)
+* Only depend on `bifunctor-classes-compat` if building with GHC 8.0.
 
 5.6 [2023.03.12]
 ----------------

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -36,7 +36,7 @@
 * Add Template Haskell `Lift` instances for all the types other than `Day`.
 * Add a `Category` instance for `Flip`.
 
-5.6.1 [2023.mm.dd]
+5.6.1 [2023.03.13]
 ------------------
 * Provide instances for the `Swap` and `Assoc` type classes from the `assoc`
   package. (These instances were previously defined in `assoc` itself, but they

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -36,6 +36,10 @@
 * Add Template Haskell `Lift` instances for all the types other than `Day`.
 * Add a `Category` instance for `Flip`.
 
+5.6.1 [2023.mm.dd]
+------------------
+* Provide instances for the `Swap` and `Assoc` type classes from the `assoc` package.
+
 5.6 [2023.03.12]
 ----------------
 * Drop support for GHC 7.10 and earlier.

--- a/bifunctors.cabal
+++ b/bifunctors.cabal
@@ -32,6 +32,7 @@ library
   hs-source-dirs: src
   build-depends:
     , base             >= 4.12   && < 5
+    , assoc            >= 1.1    && < 1.2
     , base-orphans     >= 0.8.4 && < 1
     , comonad          ^>= 6
     , containers       ^>= 0.6.0.1

--- a/src/Data/Bifunctor/Biff.hs
+++ b/src/Data/Bifunctor/Biff.hs
@@ -26,12 +26,14 @@ import Control.Applicative (Applicative (liftA2))
 #endif
 import Data.Biapplicative
 import Data.Bifoldable
+import Data.Bifoldable1 (Bifoldable1(..))
 import Data.Bifunctor
 import Data.Bifunctor.ShowRead
 import Data.Bifunctor.Unsafe
 import Data.Bifunctor.Swap (Swap (..))
 import Data.Bitraversable
 import Data.Data
+import Data.Foldable1 (Foldable1(..))
 import Data.Functor.Classes
 import GHC.Generics
 import Language.Haskell.TH.Syntax (Lift)
@@ -105,6 +107,10 @@ instance (Biapplicative p, Applicative f, Applicative g) => Biapplicative (Biff 
 instance (Bifoldable p, Foldable f, Foldable g) => Bifoldable (Biff p f g) where
   bifoldMap f g = bifoldMap (foldMap f) (foldMap g) .# runBiff
   {-# inline bifoldMap #-}
+
+instance (Bifoldable1 p, Foldable1 f, Foldable1 g) => Bifoldable1 (Biff p f g) where
+  bifoldMap1 f g = bifoldMap1 (foldMap1 f) (foldMap1 g) . runBiff
+  {-# inline bifoldMap1 #-}
 
 instance (Bitraversable p, Traversable f, Traversable g) => Bitraversable (Biff p f g) where
   bitraverse f g = fmap Biff . bitraverse (traverse f) (traverse g) .# runBiff

--- a/src/Data/Bifunctor/Biff.hs
+++ b/src/Data/Bifunctor/Biff.hs
@@ -29,6 +29,7 @@ import Data.Bifoldable
 import Data.Bifunctor
 import Data.Bifunctor.ShowRead
 import Data.Bifunctor.Unsafe
+import Data.Bifunctor.Swap (Swap (..))
 import Data.Bitraversable
 import Data.Data
 import Data.Functor.Classes
@@ -108,3 +109,7 @@ instance (Bifoldable p, Foldable f, Foldable g) => Bifoldable (Biff p f g) where
 instance (Bitraversable p, Traversable f, Traversable g) => Bitraversable (Biff p f g) where
   bitraverse f g = fmap Biff . bitraverse (traverse f) (traverse g) .# runBiff
   {-# inline bitraverse #-}
+
+-- | @since 5.6.1
+instance (f ~ g, Functor f, Swap p) => Swap (Biff p f g) where
+  swap = Biff . swap . runBiff

--- a/src/Data/Bifunctor/Flip.hs
+++ b/src/Data/Bifunctor/Flip.hs
@@ -23,6 +23,8 @@ import Data.Bifoldable1 (Bifoldable1(..))
 import Data.Bifunctor
 import Data.Bifunctor.ShowRead
 import Data.Bifunctor.Functor
+import Data.Bifunctor.Swap (Swap (..))
+import Data.Bifunctor.Assoc (Assoc (..))
 import Data.Bitraversable
 import Data.Data
 import Data.Functor.Classes
@@ -113,3 +115,11 @@ instance Cat.Category c => Cat.Category (Flip c) where
   Flip x . Flip y = Flip (y Cat.. x)
   {-# INLINE (.) #-}
 
+-- | @since 5.6.1
+instance Assoc p => Assoc (Flip p) where
+    assoc   = Flip . first Flip . unassoc . second runFlip . runFlip
+    unassoc = Flip . second Flip . assoc . first runFlip . runFlip
+
+-- | @since 5.6.1
+instance Swap p => Swap (Flip p) where
+    swap = Flip . swap . runFlip

--- a/src/Data/Bifunctor/Product.hs
+++ b/src/Data/Bifunctor/Product.hs
@@ -29,6 +29,7 @@ import Data.Bifunctor
 import Data.Bifunctor.Classes
 import Data.Bifunctor.Functor
 import Data.Bifunctor.Monoid
+import Data.Bifunctor.Swap (Swap (..))
 import Data.Bitraversable
 import Data.Data
 import Data.Functor.Classes
@@ -170,3 +171,7 @@ instance (A.ArrowZero p, A.ArrowZero q) => A.ArrowZero (Product p q) where
 instance (A.ArrowPlus p, A.ArrowPlus q) => A.ArrowPlus (Product p q) where
   (<+>) = \(Pair x y) (Pair x' y') -> Pair (x A.<+> x') (y A.<+> y')
   {-# inline (<+>) #-}
+
+-- | @since 5.6.1
+instance (Swap p, Swap q) => Swap (Product p q) where
+    swap (Pair p q) = Pair (swap p) (swap q)

--- a/src/Data/Bifunctor/Sum.hs
+++ b/src/Data/Bifunctor/Sum.hs
@@ -8,13 +8,14 @@
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE Safe #-}
 
-module Data.Bifunctor.Sum 
+module Data.Bifunctor.Sum
 ( Sum(..)
 ) where
 
 import Data.Bifunctor
 import Data.Bifunctor.Classes
 import Data.Bifunctor.Functor
+import Data.Bifunctor.Swap (Swap (..))
 import Data.Bifoldable
 import Data.Bitraversable
 import Data.Data
@@ -123,3 +124,8 @@ instance Bifunctor' p => BifunctorMonad (Sum p) where
     L2 p -> L2 p
     R2 q -> f q
   {-# inline bibind #-}
+
+-- | @since 5.6.1
+instance (Swap p, Swap q) => Swap (Sum p q) where
+  swap (L2 p) = L2 (swap p)
+  swap (R2 q) = R2 (swap q)

--- a/src/Data/Bifunctor/Tannen.hs
+++ b/src/Data/Bifunctor/Tannen.hs
@@ -28,6 +28,7 @@ import Data.Bifunctor as B
 import Data.Bifunctor.Functor
 import Data.Bifunctor.ShowRead
 import Data.Bifunctor.Unsafe
+import Data.Bifunctor.Swap (Swap (..))
 import Data.Biapplicative
 import Data.Bifoldable
 import Data.Bifoldable1 (Bifoldable1(..))
@@ -176,3 +177,6 @@ instance (Applicative f, ArrowPlus p) => ArrowPlus (Tannen f p) where
   (<+>) = \fg -> Tannen #. liftA2 (<+>) (runTannen fg) .# runTannen
   {-# inline (<+>) #-}
 
+-- | @since 5.6.1
+instance (Functor f, Swap p) => Swap (Tannen f p) where
+  swap = Tannen . fmap swap . runTannen


### PR DESCRIPTION
This forward-ports #121 to `main`, as well as a `Bifoldable1` instance for `Biff` that was mistakenly left out of #116.